### PR TITLE
Feat/spw2323 plugin cdn images

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This plugin is made for easier access to Showpass Events API data. It allows to 
    3.2. [Showpass get Event Time](#32-showpass-get-event-time)    
    3.3. [Showpass get Timezone](#33-showpass-get-timezone)    
    3.4. [Showpass get Price Range](#34-showpass-get-price-range)   
-   3.5. [Showpass get Previous or next page](#35-showpass-get-previous-or-next-page)   
+   3.5. [Showpass get Previous or next page](#35-showpass-get-previous-or-next-page)  
    3.6. [Showpass get Responsive Image](#36-showpass-get-responsive-image)
 4. [JSON Data](#4-json-data)     
    4.1. [Single event](#41-single-event)    
@@ -338,10 +338,15 @@ ex. You will have (the API will receive) 5 pages with 6 events on each page. So,
 ### Usage
 ```php
 <?php
+   // must declare showpass_image_formatter
    global $showpass_image_formatter;
+
+   // get showpass event data
    $event_data = json_decode(do_shortcode('[showpass_events template="data"]'), true);
 
+   // img src
    $img_url = $event_data['image_banner'];
+   // img options
    $options = [
       'alt' => $event_data['name'], 
       'title' => $event_data['name']
@@ -353,11 +358,12 @@ ex. You will have (the API will receive) 5 pages with 6 events on each page. So,
 ?>
 // template implementation ...
 
+// echo responsive image: <picure>
 <?= $showpass_image_formatter->getResponsiveImage($img_url, $options)  ?>
 
 ```
 
-`$showpass_image_formatter->getResponsiveImage($src, $options)`  
+### `$showpass_image_formatter->getResponsiveImage($src, $options)`  
 This function generates a responsive image.
 
 - `$src` - __String__ Showpass event image source. __Must be a `CloudFront` image__  

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ ex. You will have (the API will receive) 5 pages with 6 events on each page. So,
 ?>
 // template implementation ...
 
-// echo responsive image: <picure>
+// echo responsive image: <picture>
 <?= $showpass_image_formatter->getResponsiveImage($img_url, $options)  ?>
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This plugin is made for easier access to Showpass Events API data. It allows to 
    3.3. [Showpass get Timezone](#33-showpass-get-timezone)    
    3.4. [Showpass get Price Range](#34-showpass-get-price-range)   
    3.5. [Showpass get Previous or next page](#35-showpass-get-previous-or-next-page)   
+   3.6. [Showpass get Responsive Image](#36-showpass-get-responsive-image)
 4. [JSON Data](#4-json-data)     
    4.1. [Single event](#41-single-event)    
    4.2. [List events](#42-list-events)    
@@ -332,6 +333,51 @@ ex. You will have (the API will receive) 5 pages with 6 events on each page. So,
 
 		?>
 
+## 3.6. Showpass get responsive image
+
+### Usage
+```php
+<?php
+   global $showpass_image_formatter;
+   $event_data = json_decode(do_shortcode('[showpass_events template="data"]'), true);
+
+   $img_url = $event_data['image_banner'];
+   $options = [
+      'alt' => $event_data['name'], 
+      'title' => $event_data['name']
+      'attr' => [
+         'id' => 'custom-id',
+         'class' => 'custom-class'
+      ]
+   ];
+?>
+// template implementation ...
+
+<?= $showpass_image_formatter->getResponsiveImage($img_url, $options)  ?>
+
+```
+
+`$showpass_image_formatter->getResponsiveImage($src, $options)`  
+This function generates a responsive image.
+
+- `$src` - __String__ Showpass event image source. __Must be a `CloudFront` image__  
+
+- `$options` - __Array__  Image Options. `['option_name' => value]`
+   - `alt` - __String__ Alt attribute.
+   - `title` - __String__ Title attrinute.
+   - `image-format` - __String__ Desired image format.  
+   __default:__ `'jpeg'`
+   - `attr` - __Array__ Additional html attributes. `['attribute_name' => value]`
+   - `breakpoints` - __Array__ List of desired breakpoints. `[[size, media-query]]`.  
+   __default:__
+      ```php
+      [
+         [960, '(max-width: 960px) and (min-width: 781px)'], 
+         [780, '(max-width: 780px) and (min-width: 601px)'], 
+         [600, '(max-width: 600px) and (min-width: 376px)'], 
+         [375, '(max-width: 375px)']
+      ]
+      ```
 
 ## 4. JSON Data
 

--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -425,13 +425,44 @@ a {
   content: '\00bb';
 }
 
-.showpass-detail-image {
-  max-width: 100% !important;
-  width: 100% !important;
-  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.5);
-  border-radius: 4px;
+.showpass-detail-image-container {
+  /* 2-1 ratio fix */
+  display: block;
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  /* end 2-1 ratio fix */
   margin-bottom: 20px;
   margin-top: 20px;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.5);
+  border-radius: 4px;
+}
+/* 2-1 ratio fix */
+.showpass-detail-image-container::before {
+  display: block;
+  content: "";
+  width: 100%;
+  padding-top: 50%;
+}
+/* 2-1 ratio fix */
+.showpass-detail-image-container > picture {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.showpass-detail-image-container .showpass-detail-image {
+  /* object-fit contain fix */
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: auto;
+  height: auto;
+  min-width: 100%;
+  min-height: 100%;
 }
 
 .showpass-detail-event-name {
@@ -469,10 +500,47 @@ a {
 }
 
 .showpass-image {
-  max-width: 100% !important;
-  width: 100% !important;
-  padding-top: 50% !important;
-  background-size: cover !important;
+  max-width: 100%;
+  width: 100%;
+  padding-top: 50%;
+  background-size: cover;
+}
+
+.showpass-image.ratio {
+  width: 100%;
+  position: relative;
+  display: block;
+  overflow: hidden;
+}
+
+.showpass-image.ratio.banner {
+  padding-top: 50%;
+}
+
+.showpass-image.ratio.square {
+  padding-top: 100%;
+}
+
+.showpass-image.ratio.full-height {
+  height: 100%;
+}
+
+.showpass-image.ratio > picture {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.showpass-image.ratio > picture > img,
+.showpass-image.ratio > img {
+  position: absolute;
+  object-fit: cover;
+  height: 100%;
+  width: 100%;
+  top: 0;
+  left: 0;
 }
 
 .showpass-image-banner {

--- a/plugin/inc/default-detail.php
+++ b/plugin/inc/default-detail.php
@@ -1,5 +1,5 @@
 <?php
-	global $sp_image_formatter;
+	global $showpass_image_formatter;
 
 	$event_data = json_decode($data, true);
 ?>
@@ -20,7 +20,7 @@
 				<div class="showpass-detail-image-container">
 					<?= 
 						isset($event_data['image_banner']) 
-							? $sp_image_formatter->getResponsiveImage($event_data['image_banner'], ['alt' => $event_data['name'], 'title' => $event_data['name'], 'attr' => ['class' => 'showpass-detail-image'] ]) 
+							? $showpass_image_formatter->getResponsiveImage($event_data['image_banner'], ['alt' => $event_data['name'], 'title' => $event_data['name'], 'attr' => ['class' => 'showpass-detail-image'] ]) 
 							: sprintf('<img class="showpass-detail-image" src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event_data['name']);
 					?>
 				</div>

--- a/plugin/inc/default-detail.php
+++ b/plugin/inc/default-detail.php
@@ -1,6 +1,13 @@
-<div id="page" class="showpass-flex-box">
+<?php
+	global $sp_image_formatter;
+
+	$event_data = json_decode($data, true);
+?>
+
+
+<div id="page" class="showpass-flex-box">	
 	<?php
-	 $event_data = json_decode($data, true);
+	 
   	if (isset($event_data['detail'])) { ?>
   		<div class="showpass-layout-flex">
   			<h2>Sorry, we cannot find the event that you are looking for!</h2>
@@ -10,7 +17,11 @@
 		$current_event = $event['id'];?>
 		<div class="showpass-layout-flex showpass-detail-event-name">
 			<div class="flex-100 showpass-flex-column showpass-no-border">
-				<img class="showpass-detail-image" alt="<?php echo $event['name']; ?>" src="<?php if ($event['image_banner']) { echo $event['image_banner']; } else { echo plugin_dir_url(__FILE__).'../images/default-banner.jpg';}?>" />
+				<?= 
+					isset($event_data['image_banner']) 
+						? $sp_image_formatter->getResponsiveImage($event_data['image_banner'], ['alt' => $event_data['name'], 'title' => $event_data['name'], 'attr' => ['class' => 'showpass-detail-image'] ]) 
+						: sprintf('<img class="showpass-detail-image" src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event_data['name']);
+				?>
 			</div>
 		</div>
 		<div class="showpass-layout-flex showpass-detail-event-name">

--- a/plugin/inc/default-detail.php
+++ b/plugin/inc/default-detail.php
@@ -16,12 +16,14 @@
 		$event = $event_data;
 		$current_event = $event['id'];?>
 		<div class="showpass-layout-flex showpass-detail-event-name">
-			<div class="flex-100 showpass-flex-column showpass-no-border">
-				<?= 
-					isset($event_data['image_banner']) 
-						? $sp_image_formatter->getResponsiveImage($event_data['image_banner'], ['alt' => $event_data['name'], 'title' => $event_data['name'], 'attr' => ['class' => 'showpass-detail-image'] ]) 
-						: sprintf('<img class="showpass-detail-image" src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event_data['name']);
-				?>
+			<div class="flex-100 showpass-no-border showpass-flex-column">
+				<div class="showpass-detail-image-container">
+					<?= 
+						isset($event_data['image_banner']) 
+							? $sp_image_formatter->getResponsiveImage($event_data['image_banner'], ['alt' => $event_data['name'], 'title' => $event_data['name'], 'attr' => ['class' => 'showpass-detail-image'] ]) 
+							: sprintf('<img class="showpass-detail-image" src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event_data['name']);
+					?>
+				</div>
 			</div>
 		</div>
 		<div class="showpass-layout-flex showpass-detail-event-name">

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -2,7 +2,7 @@
 	global $sp_image_formatter;
 	/**
 	 * Custom breakpoints for responsive image.
-	 * Add max 980-1920 breakpoint, column layout only allow for a max width of 640px up to 1920.
+	 * Add max 980-1920 breakpoint, column layout only allows for a max width of 640px.
 	 * 600px x 600px is already cached, so use that image.
 	 */
 	$image_breakpoints = [

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -1,5 +1,5 @@
 <?php 
-	global $sp_image_formatter;
+	global $showpass_image_formatter;
 	/**
 	 * Custom breakpoints for responsive image.
 	 * Add max 980-1920 breakpoint, column layout only allows for a max width of 640px.
@@ -42,7 +42,7 @@
 					<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
 							<a href="<?= $event_href ?>" class="showpass-image ratio banner">
 								<?= isset($event['image_banner']) 
-									? $sp_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'title' => $event['name'], 'breakpoints' => $image_breakpoints]) 
+									? $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'title' => $event['name'], 'breakpoints' => $image_breakpoints]) 
 									: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
 						 		?>
 							</a>

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -1,20 +1,51 @@
+<?php 
+	global $sp_image_formatter;
+	/**
+	 * Custom breakpoints for responsive image.
+	 * Add max 980-1920 breakpoint, column layout only allow for a max width of 640px up to 1920.
+	 * 600px x 600px is already cached, so use that image.
+	 */
+	$image_breakpoints = [
+		[600, '(max-width: 1920px) and (min-width: 981px)'],
+		[960, '(max-width: 980px) and (min-width: 781px)'], 
+		[780, '(max-width: 780px) and (min-width: 601px)'], 
+		[600, '(max-width: 600px) and (min-width: 376px)'], 
+		[375, '(max-width: 375px)']
+	];
+
+	$event_data = json_decode($data, true);
+?>
+
 <div class="showpass-flex-box">
 	<div class="showpass-layout-flex">
 			<?php
-			$event_data = json_decode($data, true);
 			if ($event_data['count'] > 0) {
 				$events = $event_data['results'];
-				foreach ($events as $key => $event) { ?>
+				foreach ($events as $key => $event) {
+					// default event link does nothing
+					$event_href = 'javascript:void(0);';
+					// only set link if not sold out
+					if ( !showpass_ticket_sold_out($event) ) {
+						/**
+						 * if detail_page is setup, then link to the detail page
+						 * otherwise link externally
+						 */
+						if (isset($detail_page)) {
+							$event_href = sprintf('/%s/?slug=%s', $detail_page, $event['slug']);
+						} else if (isset($event['external_link'])) {
+							$event_href = $event['external_link'];
+						}
+					}
+				?>	
 				<div class="showpass-flex-column showpass-no-border showpass-event-card showpass-grid">
 					<div class="showpass-event-list showpass-layout-flex m15">
-						<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
-							<?php if ($detail_page) { ?>
-								<a class="showpass-image" style="background-image: url('<?php if ($event['image_banner']) { echo $event['image_banner']; } else { echo plugin_dir_url(__FILE__).'../images/default-banner.jpg';}?>');" href="/<?php echo $detail_page; ?>/?slug=<?php echo $event['slug']; ?>"></a>
-							<?php } else if(showpass_ticket_sold_out($event)) {?>
-								<a class="showpass-image showpass-soldout" style="background-image: url('<?php if ($event['image_banner']) { echo $event['image_banner']; } else { echo plugin_dir_url(__FILE__).'../images/default-banner.jpg';}?>');"></a>
-							<?php } else {?>
-								<a class="showpass-image <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?> style="background-image: url('<?php if ($event['image_banner']) { echo $event['image_banner']; } else { echo plugin_dir_url(__FILE__).'../images/default-banner.jpg';}?>');"></a>
-							<?php } ?>
+					<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
+							<a href="<?= $event_href ?>" class="showpass-image ratio banner">
+								<?= isset($event['image_banner']) 
+									? $sp_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'title' => $event['name'], 'breakpoints' => $image_breakpoints]) 
+									: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
+						 		?>
+							</a>
 						</div>
 						<div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white">
 							<div class="showpass-full-width">

--- a/plugin/inc/default-list.php
+++ b/plugin/inc/default-list.php
@@ -1,5 +1,5 @@
 <?php
-	global $sp_image_formatter;
+	global $showpass_image_formatter;
 
 	$event_data = json_decode($data, true);
 ?>
@@ -38,7 +38,7 @@
               <?php endif ?> 
             >
               <?= isset($event['image']) 
-                ? $sp_image_formatter->getResponsiveImage($event['image'], ['alt' => $event['name']]) 
+                ? $showpass_image_formatter->getResponsiveImage($event['image'], ['alt' => $event['name']]) 
                 : sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-square.jpg', $event['name']);
               ?>
             </a>
@@ -51,7 +51,7 @@
               <?php endif ?> 
             >
               <?= isset($event['image_banner']) 
-                ? $sp_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name']]) 
+                ? $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name']]) 
                 : sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
               ?>
             </a>

--- a/plugin/inc/default-pricing-table.php
+++ b/plugin/inc/default-pricing-table.php
@@ -1,3 +1,19 @@
+<?php 
+	global $sp_image_formatter;
+	/**
+	 * Custom breakpoints for responsive image.
+	 * Add max 980-1920 breakpoint, column layout only allow for a max width of 640px up to 1920.
+	 * 600px x 600px is already cached, so use that image.
+	 */
+	$image_breakpoints = [
+		[600, '(max-width: 1920px) and (min-width: 981px)'],
+		[960, '(max-width: 980px) and (min-width: 781px)'], 
+		[780, '(max-width: 780px) and (min-width: 601px)'], 
+		[600, '(max-width: 600px) and (min-width: 376px)'], 
+		[375, '(max-width: 375px)']
+	];
+?>
+
 <div class="showpass-flex-box showpass-pricing-table">
 	<div class="showpass-layout-flex justify-center">
 			<?php
@@ -6,7 +22,12 @@
 				<div class="showpass-flex-column showpass-no-border showpass-event-card showpass-grid">
 					<div class="showpass-event-list showpass-layout-flex m15 layout-fill">
 						<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
-							<span class="showpass-image" style="background-image: url('<?php if ($event['image_banner']) { echo $event['image_banner']; } else { echo plugin_dir_url(__FILE__).'../images/default-banner.jpg';}?>');"></span>
+							<div class="showpass-image ratio banner">
+								<?= isset($event['image_banner']) 
+									? $sp_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'breakpoints' => $image_breakpoints]) 
+									: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
+						 		?>
+							</div>
 						</div>
 						<div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white">
 							<div class="showpass-full-width">

--- a/plugin/inc/default-pricing-table.php
+++ b/plugin/inc/default-pricing-table.php
@@ -1,5 +1,5 @@
 <?php 
-	global $sp_image_formatter;
+	global $showpass_image_formatter;
 	/**
 	 * Custom breakpoints for responsive image.
 	 * Add max 980-1920 breakpoint, column layout only allow for a max width of 640px up to 1920.
@@ -24,7 +24,7 @@
 						<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
 							<div class="showpass-image ratio banner">
 								<?= isset($event['image_banner']) 
-									? $sp_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'breakpoints' => $image_breakpoints]) 
+									? $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'breakpoints' => $image_breakpoints]) 
 									: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
 						 		?>
 							</div>

--- a/plugin/inc/default-product-grid.php
+++ b/plugin/inc/default-product-grid.php
@@ -1,14 +1,44 @@
+<?php 
+	global $sp_image_formatter;
+	/**
+	 * Custom breakpoints for responsive image.
+	 * Add max 980-1920 breakpoint, column layout only allows for a max width of 640px.
+	 * 600px x 600px is already cached, so use that image.
+	 */
+	$image_breakpoints = [
+		[600, '(max-width: 1920px) and (min-width: 981px)'],
+		[960, '(max-width: 980px) and (min-width: 781px)'], 
+		[780, '(max-width: 780px) and (min-width: 601px)'], 
+		[600, '(max-width: 600px) and (min-width: 376px)'], 
+		[375, '(max-width: 375px)']
+	];
+
+	$product_data = json_decode($data, true);
+
+	// <pre style="font-size: 12px">
+
+	// </pre>
+?>
+
 <div class="showpass-flex-box">
 	<div class="showpass-layout-flex">
 			<?php
-			$product_data = json_decode($data, true);
 			if ($product_data['count'] > 0) {
 				$products = $product_data['results'];
 				foreach ($products as $key => $product) { ?>
+				
 				<div class="flex-50 showpass-prodcut-grid-flex showpass-flex-column showpass-no-border showpass-event-card">
 					<div class="showpass-event-list showpass-layout-flex m15">
 						<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
-							<a class="showpass-image-banner open-product-widget" id="<?php echo $product['id']; ?>" style="background-image: url('<?php if ($product['thumbnail']) { echo $product['thumbnail']; } else { echo plugin_dir_url(__FILE__).'../images/default-square.jpg';}?>');"></a>
+							<a 
+								id="<?php echo $product['id']; ?>" 
+								class="showpass-image open-product-widget ratio square" 
+							>
+								<?= isset($product['image']) 
+									? $sp_image_formatter->getResponsiveImage($product['image'], ['alt' => $product['name']]) 
+									: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-square.jpg', $product['name']);
+								?>
+							</a>
 						</div>
 						<div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white">
 							<div class="showpass-full-width">

--- a/plugin/inc/default-product-grid.php
+++ b/plugin/inc/default-product-grid.php
@@ -1,5 +1,5 @@
 <?php 
-	global $sp_image_formatter;
+	global $showpass_image_formatter;
 	/**
 	 * Custom breakpoints for responsive image.
 	 * Add max 980-1920 breakpoint, column layout only allows for a max width of 640px.
@@ -35,7 +35,7 @@
 								class="showpass-image open-product-widget ratio square" 
 							>
 								<?= isset($product['image']) 
-									? $sp_image_formatter->getResponsiveImage($product['image'], ['alt' => $product['name']]) 
+									? $showpass_image_formatter->getResponsiveImage($product['image'], ['alt' => $product['name']]) 
 									: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-square.jpg', $product['name']);
 								?>
 							</a>

--- a/plugin/inc/default-product-list.php
+++ b/plugin/inc/default-product-list.php
@@ -1,7 +1,20 @@
+<?php
+	global $sp_image_formatter;
+	
+	// image container is a static 300x300 @ 780px wide
+	const BREAKPOINTS = [
+		[300, '(min-width: 781px)'], 
+		[780, '(max-width: 780px) and (min-width: 601px)'], 
+		[600, '(max-width: 600px) and (min-width: 376px)'], 
+		[375, '(max-width: 375px)']
+	];
+
+	$product_data = json_decode($data, true);
+?>
+
 <div class="showpass-flex-box">
 	<div class="showpass-layout-flex">
 			<?php
-			$product_data = json_decode($data, true);
 			if ($product_data['count'] > 0) {
 				$products = $product_data['results'];
 				foreach ($products as $key => $product) {
@@ -9,7 +22,15 @@
 					<div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-event-card">
 						<div class="showpass-event-layout-list showpass-layout-flex m15">
 							<div class="card-image showpass-flex-column list-layout-flex showpass-no-border showpass-no-padding p0">
-                <a class="showpass-image-banner open-product-widget" style="background-image: url('<?php if ($product['thumbnail']) { echo $product['thumbnail']; } else { echo plugin_dir_url(__FILE__).'../images/default-square.jpg';}?>');"></a>
+								<a 
+									id="<?php echo $product['id']; ?>" 
+									class="showpass-image open-product-widget ratio square" 
+								>
+									<?= isset($product['image']) 
+										? $sp_image_formatter->getResponsiveImage($product['image'], ['alt' => $product['name']]) 
+										: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-square.jpg', $product['name']);
+									?>
+								</a>
 							</div>
 							<div class="list-info flex-70 showpass-flex-column list-layout-flex showpass-no-border showpass-background-white">
 								<div class="showpass-space-between showpass-full-width showpass-layout-fill">

--- a/plugin/inc/default-product-list.php
+++ b/plugin/inc/default-product-list.php
@@ -1,5 +1,5 @@
 <?php
-	global $sp_image_formatter;
+	global $showpass_image_formatter;
 	
 	// image container is a static 300x300 @ 780px wide
 	const BREAKPOINTS = [
@@ -27,7 +27,7 @@
 									class="showpass-image open-product-widget ratio square" 
 								>
 									<?= isset($product['image']) 
-										? $sp_image_formatter->getResponsiveImage($product['image'], ['alt' => $product['name']]) 
+										? $showpass_image_formatter->getResponsiveImage($product['image'], ['alt' => $product['name']]) 
 										: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-square.jpg', $product['name']);
 									?>
 								</a>

--- a/plugin/inc/image-formatter.class.php
+++ b/plugin/inc/image-formatter.class.php
@@ -1,0 +1,79 @@
+<?php 
+  namespace Showpass;
+
+  class ImageFormater {
+
+    const CLOUDFRONT_REGEX = '/(https:\/\/\w*\.cloudfront.net\/)/';
+    const CLOUDFRON_BASE_URL = 'https://dcm1eeuyachdi.cloudfront.net/';
+    const BREAKPOINTS = [[960, '(max-width: 960px) and (min-width: 781px)'], [780, '(max-width: 780px) and (min-width: 601px)'], [600, '(max-width: 600px) and (min-width: 376px)'], [375, '(max-width: 375px)']];
+    const IMAGE_FORMAT = 'jpeg';
+
+    function __construct() {}
+
+    public function getResponsiveImage(
+      $src, 
+      $options = []
+    ) {
+      /**
+       * Get all options and set defaults.
+       */
+      $attr = isset($options['attr']) ? $options['attr'] : [];
+      $format = isset($options['image-format']) ? $options['image-format'] : self::IMAGE_FORMAT;
+      $breakpoints = isset($options['breakpoints']) ? $options['breakpoints'] : self::BREAKPOINTS;
+
+      // add alt to attributes so it can be printed out on the img tag
+      if (isset($options['alt'])) {
+        $attr['alt'] = $options['alt'];
+      }
+      // add title to attributes so it can be printed out on the img tag
+      if (isset($options['title'])) {
+        $attr['title'] = $options['title'];
+      }
+
+      /**
+       * Get relative path to image.
+       * 
+       * $splitURL[0] = base
+       * $splitURL[1] = relative path
+       */
+      $splitURL = preg_split(self::CLOUDFRONT_REGEX, $src, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+
+      $sources = [];
+      for ($i = 0; $i < count($breakpoints); $i++) {
+        // create source element
+        $imgSize = sprintf('fit-in/%sx%s/', $breakpoints[$i][0], $breakpoints[$i][0]);
+        $imgFormat = sprintf('filters:format(%s)/', $format);
+        $imgSrc = self::CLOUDFRON_BASE_URL . $imgSize .  $imgFormat . $splitURL[1];
+
+        // add source to sources array
+        $sources[$i] = sprintf('<source media="%s" srcset="%s">', $breakpoints[$i][1], $imgSrc);
+      }
+      unset($i, $imgSize, $imgFormat, $imgSrc);
+
+      return $this->generateResponsiveTag($src, $sources, $attr);
+    }
+
+    private function generateResponsiveTag($default, $sources, $attr = []) {
+      // create attributes string
+      $attributes = '';
+      foreach ($attr as $key => $value) {
+        $attributes .= sprintf('%s="%s" ', $key, $value);
+      }
+      unset($key, $value);
+
+      // create picture element
+      $picture = '<picture>';
+      // add all sources to picture
+      foreach ($sources as &$source) {
+        $picture .= $source;
+      }
+      unset($source);
+
+      // set default image
+      $picture .= sprintf('<img src="%s" %s>', $default, $attributes);
+      $picture .= '</picture>';
+
+      return $picture;
+    }
+  }
+?>

--- a/plugin/inc/image-formatter.class.php
+++ b/plugin/inc/image-formatter.class.php
@@ -2,7 +2,7 @@
   namespace Showpass;
   use Exception;
 
-  class ImageFormater {
+  class ImageFormatter {
 
     const CLOUDFRONT_REGEX = '/(https:\/\/\w*\.cloudfront.net\/)/';
     const CLOUDFRON_BASE_URL = 'https://dcm1eeuyachdi.cloudfront.net/';
@@ -11,6 +11,13 @@
 
     function __construct() {}
 
+      /**
+       * Creates a responsive image using the CloudFront service.
+       * Will create a <picture> <source> for each breakpoint/size.
+       * 
+       * @param String $src - img src
+       * @param Array $options - options key/value array
+       */
     public function getResponsiveImage(
       $src, 
       $options = []
@@ -58,6 +65,14 @@
       return $this->generateResponsiveTag($src, $sources, $attr);
     }
 
+    /**
+     * Creates an html <picture> tag.
+     * Generates a <source> tag for each item in the $source array
+     * 
+     * @param String $default - default img src
+     * @param Array $sources - source image array
+     * @param Array $attr - html attributes to apply to the <picture> tag.
+     */
     private function generateResponsiveTag($default, $sources, $attr = []) {
       // create attributes string
       $attributes = '';

--- a/plugin/inc/image-formatter.class.php
+++ b/plugin/inc/image-formatter.class.php
@@ -1,5 +1,6 @@
 <?php 
   namespace Showpass;
+  use Exception;
 
   class ImageFormater {
 
@@ -37,6 +38,10 @@
        * $splitURL[1] = relative path
        */
       $splitURL = preg_split(self::CLOUDFRONT_REGEX, $src, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+
+      if (count($splitURL) < 2) {
+        throw new Exception('Error: must supply cloudfront image.');
+      } 
 
       $sources = [];
       for ($i = 0; $i < count($breakpoints); $i++) {

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -20,8 +20,8 @@ add_action('admin_menu', 'wpshp_admin_menu');
 add_action( 'template_redirect', function() {
     require_once plugin_dir_path( __FILE__ ) . 'inc/image-formatter.class.php';
 
-    global $sp_image_formatter;
-    $sp_image_formatter = new Showpass\ImageFormater();    
+    global $showpass_image_formatter;
+    $showpass_image_formatter = new Showpass\ImageFormater();    
  } );
 
 function wpshp_admin_menu()

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -17,12 +17,15 @@ if (! defined('ABSPATH')) {
 *************************************/
 add_action('admin_menu', 'wpshp_admin_menu');
 
+/**
+ * imports and sets Showpass\ImageFormatter whenever a frontend template is loaded.
+ */
 add_action( 'template_redirect', function() {
     require_once plugin_dir_path( __FILE__ ) . 'inc/image-formatter.class.php';
 
     global $showpass_image_formatter;
-    $showpass_image_formatter = new Showpass\ImageFormater();    
- } );
+    $showpass_image_formatter = new Showpass\ImageFormatter();    
+});
 
 function wpshp_admin_menu()
 {

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -17,6 +17,13 @@ if (! defined('ABSPATH')) {
 *************************************/
 add_action('admin_menu', 'wpshp_admin_menu');
 
+add_action( 'template_redirect', function() {
+    require_once plugin_dir_path( __FILE__ ) . 'inc/image-formatter.class.php';
+
+    global $sp_image_formatter;
+    $sp_image_formatter = new Showpass\ImageFormater();    
+ } );
+
 function wpshp_admin_menu()
 {
 

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -4,7 +4,7 @@
      Plugin URI: https://github.com/showpass/showpass-wordpress-plugin
      Description: List events, display event details and products. Use the Showpass purchase widget for on site ticket & product purchases all with easy to use shortcodes. See our git repo here for full documentation. https://github.com/showpass/showpass-wordpress-plugin
      Author: Showpass / Up In Code Inc.
-     Version: 3.3.5
+     Version: 3.3.6
      Author URI: https://www.showpass.com
      */
 


### PR DESCRIPTION
Created an image formatter class.

The `getResponsiveImage` function generates an html <picture> tag with embedded <source> tags relative to the $breakpoints array.

**Acceptance Testing**

1. All images should be responsive when using the following WordPress plugin shortcodes:
- [showpass_events type="list" detail_page='event-detail' template='list']
- [showpass_events type="list" detail_page='event-detail' template='grid']
- [showpass_events type="detail"]
- [showpass_products template="list" page_size="8"]
- [showpass_products template="grid" page_size="8"]
- [showpass_pricing_table ids="15105,15838,8187"]

2. Create a page and test each shortcode for the following: 
- The downloaded image in the network tab should correspond to the breakpoints
- Image links should still work in the following states (available, sold-out, detail-page & no detail-page)

The `global $showpass_image_formatter->showpass_image_formatter` should also be available to `custom-templates`.

1. Import the following code into a template:
```php 
<?php
    global $showpass_image_formatter;
    $data = json_decode(do_shortcode('[showpass_events template="data"]'), true);
    $event = $data['results'][0];

    <?= $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'title' => $event['name']])  ?>
?>
```
2. Test the custom-template page to see if different sized images are downloaded in the network tab at different breakpoints.