### PR TITLE
fix: showpass_ticket_solid_out bad key check

### DIFF
--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -331,14 +331,16 @@ function showpass_ticket_sold_out ($data) {
 			$soldout_count = 0;
 			$ticket_types_count = sizeOf($data);
 			foreach ($ticket_types as $ticket) {
-				if ($ticket['sold_out']) {
+        // use isset to make sure there is no error if the key doesn't exist
+        // or if sold_out exists but is falsy
+				if (isset($ticket['sold_out'])) {
 						$soldout_count ++ ;
 				}
-			}
+      }
 			if ($soldout_count == $ticket_types_count){
 				return true;
 			}
-			else{
+			else {
 				return false;
 			}
 		}


### PR DESCRIPTION
Should use `isset` in most cases.
The only place that `if ($arr['key']) {` should be used is when a `key => value` is expected to be `true` when `value` is an empty string. In this case a check needs to be done to see if the key exists.

**Acceptance Test**

1. Implement the function `showpass_ticket_sold_out` on a custom template or shortcode.  
This should be done for products & tickets.
2. Check to make sure that there are no errors/warnings.
3. Check to make sure that events & products have the right `sold out` flag.  
Test on both `sold out` and not `sold out` items. 