### PR TITLE
fix: implement multi-date event display

### DIFF
--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -24,6 +24,36 @@
   }
 }
 
+/* ---- Grid Overrides ---- */
+.showpass-event-card.showpass-grid {
+  position: relative;
+  align-items: stretch!important;
+}
+
+.showpass-event-grid {
+  min-height: 230px;
+  background: none !important;
+  margin-left: 0px !important;
+  margin-right: 0px !important;
+  margin-bottom: 30px;
+  position: relative;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.3);
+}
+
+@media screen and (min-width: 600px) {
+  .showpass-grid .action-bar {
+    position: absolute;
+    bottom: 0;
+    width: 100%;
+  }
+
+  .showpass-event-grid {
+    padding-bottom: 56px;
+  }
+}
+
+/* ---- Grid Overrides ---- */
+
 .showpass-event-card .showpass-event-list .showpass-background-white, .showpass-event-card .showpass-event-layout-list .showpass-background-white{
   background-color: white;
   color: black;
@@ -151,6 +181,10 @@
   box-sizing: border-box;
   margin-top: 15px;
   text-decoration: none !important;
+}
+
+.showpass-list-ticket-button.no-margin {
+  margin-top: 0;
 }
 
 .showpass-list-ticket-button:focus {
@@ -593,6 +627,15 @@ a {
 
 .showpass-detail-event-date .info {
   margin-bottom: 10px;
+}
+
+.showpass-detail-event-date .info.dates .display-inline-block {
+  display: inline-block;
+  vertical-align: top;
+}
+
+.showpass-detail-event-date .info.dates .label {
+  margin-right: 10px;
 }
 
 .showpass-detail-event-date .info.badges {

--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -282,6 +282,20 @@ a {
   text-align: left;
 }
 
+.showpass-detail-event-date .info.event-date {
+  display: flex;
+}
+
+.info span.start-date.multi-date::after {
+  content: "-";
+  margin: 0 5px;
+}
+
+.showpass-detail-event-date .info.event-date span.start-date,
+.showpass-detail-event-date .info.event-date span.end-date {
+  display: block;
+}
+
 .showpass-event-title h3 {
   color: black !important;
   font-weight: 100 !important;

--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -263,6 +263,20 @@ a {
   }
 }
 
+/* ================
+   COMPONENT STYLES 
+   ================ */
+.badge {
+  background: #bfbfbf;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  line-height: 1;
+  padding: 4px 6px;
+  text-transform: uppercase;
+}
+
 .showpass-price-display {
   color: #dd3333;
   font-size: 14px;
@@ -278,23 +292,7 @@ a {
   text-overflow: ellipsis;
 }
 
-.showpass-detail-event-date .info {
-  text-align: left;
-}
 
-.showpass-detail-event-date .info.event-date {
-  display: flex;
-}
-
-.info span.start-date.multi-date::after {
-  content: "-";
-  margin: 0 5px;
-}
-
-.showpass-detail-event-date .info.event-date span.start-date,
-.showpass-detail-event-date .info.event-date span.end-date {
-  display: block;
-}
 
 .showpass-event-title h3 {
   color: black !important;
@@ -527,6 +525,10 @@ a {
 
 .showpass-detail-event-date .info {
   margin-bottom: 10px;
+}
+
+.showpass-detail-event-date .info.badges {
+  padding-left: 10px;
 }
 
 .showpass-pricing-table .pricing-table-buy-now {

--- a/plugin/inc/default-detail.php
+++ b/plugin/inc/default-detail.php
@@ -34,8 +34,13 @@
 				<div class="w100">
 					<div class="showpass-detail-event-date mb30">
             <?php $location = $event['location']; ?>
-              <?php if (!$event['is_recurring_parent']) { ?>
-                <div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?></div>
+							<?php if (!$event['is_recurring_parent']) { ?>
+								<div class="info event-date">
+									<i class="fa fa-calendar icon-center"></i>
+									<div>
+										<?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
+									</div>
+								</div>
                 <div class="info"><i class="fa fa-clock-o icon-center"></i><?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?>
                 <?php echo showpass_get_timezone_abbr($event['timezone'], false);?></div>
 							<?php } else { ?>

--- a/plugin/inc/default-detail.php
+++ b/plugin/inc/default-detail.php
@@ -15,6 +15,7 @@
 		<div class="showpass-layout-flex showpass-detail-event-name">
 			<div class="flex-100 showpass-flex-column showpass-no-border"><h1 class="w100"><?php echo $event['name']; ?></h1></div>
 		</div>
+	
 		<div class="flex-container showpass-layout-flex">
 			<div class="flex-66 showpass-flex-column showpass-no-border">
 				<div class="w100">
@@ -23,7 +24,7 @@
 							<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
 						</span>
 					<?php } else { ?>
-						<span class="showpass-detail-buy showpass-hide-medium <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['show_eyereturn']) {?> data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
+						<span class="showpass-detail-buy showpass-hide-medium <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if (isset($event['show_eyereturn'])) {?> data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
 							<?php include 'button-verbiage.php'; ?>
 						</span>
 					<?php } ?>
@@ -31,37 +32,48 @@
 				</div>
 			</div>
 			<div class="flex-33 showpass-flex-column showpass-no-border">
+
 				<div class="w100">
-					<div class="showpass-detail-event-date mb30">
-            <?php $location = $event['location']; ?>
-							<?php if (!$event['is_recurring_parent']) { ?>
-								<div class="info event-date">
-									<i class="fa fa-calendar icon-center"></i>
-									<div>
-										<?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
+					<!-- Event Date(s) & Badges -->
+					<div>
+						<div class="showpass-detail-event-date">
+							<div>
+								<?php if (!showpass_ticket_sold_out($event) && $event['is_recurring_parent']) : ?>
+									<div class="info badges">
+										<span class="badge">
+											<?php if (showpass_get_event_date($event['starts_on'], $event['timezone']) === showpass_get_event_date($event['ends_on'], $event['timezone'])): ?>
+												Multiple Times
+											<?php else: ?>
+												Multiple Dates
+											<?php endif ?>
+										</span>
 									</div>
-								</div>
-                <div class="info"><i class="fa fa-clock-o icon-center"></i><?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?>
-                <?php echo showpass_get_timezone_abbr($event['timezone'], false);?></div>
-							<?php } else { ?>
-                <div class="info"><i class="fa fa-calendar-plus-o icon-center"></i> Multiple Dates</div>
-							<?php } ?>
-  						<div class="info"><i class="fa fa-map-marker icon-center"></i><?php echo $location['name'];?></div>
-  						<?php if ($event['ticket_types']) : ?>
-                <div class="info mb20"><i class="fa fa-tags icon-center"></i><?php echo showpass_get_price_range($event['ticket_types']);?>
-                  <?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?></div>
-              <?php endif; ?>
-							<?php if(showpass_ticket_sold_out($event)) {?>
-								<span class="showpass-detail-buy showpass-soldout">
-									<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
-								</span>
-							<?php } else { ?>
-								<span class="showpass-detail-buy <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['show_eyereturn']) {?> data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
-                  <?php include 'button-verbiage.php'; ?>
-	            	</span>
-							<?php } ?>
+								<?php endif; ?>
+								<?= showpass_display_date($event) ?>
+								<div class="info"><i class="fa fa-map-marker icon-center"></i><?= $event['location']['name'] ?></div>
+							</div>
+						</div>
 					</div>
+					<!-- Event Date(s) & Badges -->
+
+					<div class="showpass-detail-event-date mb30">
+						<?php if ($event['ticket_types']) : ?>
+							<div class="info mb20"><i class="fa fa-tags icon-center"></i><?php echo showpass_get_price_range($event['ticket_types']);?>
+								<?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?></div>
+						<?php endif; ?>
+						<?php if(showpass_ticket_sold_out($event)) {?>
+							<span class="showpass-detail-buy showpass-soldout">
+								<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
+							</span>
+						<?php } else { ?>
+							<span class="showpass-detail-buy <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if (isset($event['show_eyereturn'])) {?> data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
+								<?php include 'button-verbiage.php'; ?>
+							</span>
+						<?php } ?>
+					</div>
+
 					<div class="text-center showpass-detail-location">
+						<?php $location = $event['location'] ?>
 						<h3 class="showpass-event-veune-name"><?php echo $location['name'];?></h3>
 						<span class="showpass-detail-address"><?php echo rtrim($location['street_name']);?>, <?php echo $location['city'];?></span>
 						<iframe width="100%" height="300" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?key=AIzaSyDe9oSMuAfjkjtblej94RJvQh3ioWJb4go&q=<?php echo urlencode($location['name']);?>,<?php echo urlencode($location['city']);?>+<?php echo urlencode($location['province']);?>
@@ -71,6 +83,7 @@
 					</div>
 				</div>
 			</div>
+
 		</div>
 	<?php } ?>
 </div>

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -18,23 +18,22 @@
 						</div>
 						<div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white">
 							<div class="showpass-full-width">
+								<!-- Ticket Pricing -->
 								<div class="showpass-layout-flex">
 									<div class="flex-100 showpass-flex-column showpass-no-border">
-                    <div>
-                      <?php if (!showpass_ticket_sold_out($event)) : ?>
-                        <small class="showpass-price-display">
-													<?php if ($event['is_recurring_parent']) { ?>
-														Multiple Dates
-													<?php } else {?>
-														<?php echo showpass_get_price_range($event['ticket_types']);?>
-														<?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
-													<?php } ?>
-                        </small>
-                      <?php endif; ?>
-                    </div>
-                    <div><?php if (showpass_ticket_sold_out($event)) : ?><small class="showpass-price-display"> No Tickets Available</small><?php endif; ?></div>
-                  </div>
+										<?php if (!showpass_ticket_sold_out($event)) : ?>
+											<small class="showpass-price-display">
+												<?php if (!$event['is_recurring_parent']) { ?>
+													<?php echo showpass_get_price_range($event['ticket_types']);?>
+													<?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
+												<?php } ?>
+											</small>
+										<?php endif; ?>
+									</div>
 								</div>
+								<!-- Ticket Pricing -->
+								
+								<!-- Event Name -->
 								<div class="showpass-layout-flex">
 									<div class="flex-100 showpass-flex-column showpass-no-border showpass-title-wrapper">
 										<div class="showpass-event-title">
@@ -46,36 +45,30 @@
 										</div>
 									</div>
 								</div>
+								<!-- Event Name -->
+
+								<!-- Event Date(s) & Badges -->
 								<div class="showpass-layout-flex">
 									<div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
 										<div>
-											<?php if ($event['is_recurring_parent']) { ?>
-												<?php if (showpass_get_event_date($event['starts_on'], $event['timezone'], false) === showpass_get_event_date($event['ends_on'], $event['timezone'], false)) { ?>
-													<!-- If recurring children on the same day -->
-													<div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?></div>
-													<div class="info"><i class="fa fa-clock-o icon-center"></i>
-														<?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?> <?php echo showpass_get_timezone_abbr($event['timezone'], false);?>
-													</div>
-												<?php } else { ?>
-													<!-- If recurring children on different days -->
-													<div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?> -</div>
-													<div class="info"><i class="fa icon-center"></i><?php echo showpass_get_event_date($event['ends_on'], $event['timezone'], false);?></div>
-												<?php } ?>
-											<?php } else {?>
-												<div class="info event-date">
-													<i class="fa fa-calendar icon-center"></i>
-													<div>
-														<?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
-													</div>
+											<?php if (!showpass_ticket_sold_out($event) && $event['is_recurring_parent']) : ?>
+												<div class="info badges">
+													<span class="badge">
+														<?php if (showpass_get_event_date($event['starts_on'], $event['timezone']) === showpass_get_event_date($event['ends_on'], $event['timezone'])): ?>
+															Multiple Times
+														<?php else: ?>
+															Multiple Dates
+														<?php endif ?>
+													</span>
 												</div>
-												<div class="info"><i class="fa fa-clock-o icon-center"></i>
-													<?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?> <?php echo showpass_get_timezone_abbr($event['timezone'], false);?>
-												</div>
-											<?php } ?>
-											<div class="info"><i class="fa fa-map-marker icon-center"></i><?php $location = $event['location']; echo $location['name'];?></div>
+											<?php endif; ?>
+											<?= showpass_display_date($event) ?>
 										</div>
 									</div>
 								</div>
+								<!-- Event Date(s) & Badges -->
+
+								<!-- Action Buttons -->
 								<div class="showpass-layout-flex">
 									<div class="showpass-layout-flex showpass-list-button-layout">
 											<div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-left">
@@ -100,6 +93,7 @@
 										<?php } ?>
 									</div>
 								</div>
+								<!-- Action Buttons -->
 							</div>
 						</div>
 					</div>

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -93,7 +93,7 @@
 													</span>
 												</div>
 											<?php endif; ?>
-											<?= showpass_display_date($event) ?>
+											<?= showpass_display_date($event, true) ?>
 										</div>
 									</div>
 								</div>

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -38,8 +38,8 @@
 					}
 				?>	
 				<div class="showpass-flex-column showpass-no-border showpass-event-card showpass-grid">
-					<div class="showpass-event-list showpass-layout-flex m15">
-					<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
+					<div class="showpass-event-grid showpass-layout-flex m15">
+						<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
 							<a href="<?= $event_href ?>" class="showpass-image ratio banner">
 								<?= isset($event['image_banner']) 
 									? $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'title' => $event['name'], 'breakpoints' => $image_breakpoints]) 
@@ -77,7 +77,7 @@
 									</div>
 								</div>
 								<!-- Event Name -->
-
+							
 								<!-- Event Date(s) & Badges -->
 								<div class="showpass-layout-flex">
 									<div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
@@ -98,35 +98,37 @@
 									</div>
 								</div>
 								<!-- Event Date(s) & Badges -->
-
-								<!-- Action Buttons -->
-								<div class="showpass-layout-flex">
-									<div class="showpass-layout-flex showpass-list-button-layout">
-											<div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-left">
-												<div class="showpass-button-full-width-grid">
-													<?php if(showpass_ticket_sold_out($event)) { ?>
-														<a class="showpass-list-ticket-button showpass-button showpass-soldout">
-															<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
-														</a>
-													<?php } else { ?>
-														<a class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
-                              <?php include 'button-verbiage.php'; ?>
-														</a>
-													<?php } ?>
-												</div>
-											</div>
-										<?php if ($detail_page) {?>
-											<div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-right">
-												<div class="showpass-button-full-width-grid">
-													<a class="showpass-list-ticket-button showpass-button-secondary" href="/<?php echo $detail_page; ?>/?slug=<?php echo $event['slug']; ?>">More Info</a>
-												</div>
-											</div>
-										<?php } ?>
-									</div>
-								</div>
-								<!-- Action Buttons -->
 							</div>
 						</div>
+
+						<!-- Action Buttons -->
+						<div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white action-bar">
+							<div class="showpass-layout-flex">
+								<div class="showpass-layout-flex showpass-list-button-layout">
+										<div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-left">
+											<div class="showpass-button-full-width-grid">
+												<?php if(showpass_ticket_sold_out($event)) { ?>
+													<a class="showpass-list-ticket-button showpass-button showpass-soldout no-margin">
+														<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
+													</a>
+												<?php } else { ?>
+													<a class="showpass-list-ticket-button showpass-button no-margin <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
+														<?php include 'button-verbiage.php'; ?>
+													</a>
+												<?php } ?>
+											</div>
+										</div>
+									<?php if ($detail_page) {?>
+										<div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-right">
+											<div class="showpass-button-full-width-grid">
+												<a class="showpass-list-ticket-button showpass-button-secondary no-margin" href="/<?php echo $detail_page; ?>/?slug=<?php echo $event['slug']; ?>">More Info</a>
+											</div>
+										</div>
+									<?php } ?>
+								</div>
+							</div>
+						</div>
+						<!-- Action Buttons -->
 					</div>
 				</div>
 			<?php } ?>

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -62,7 +62,12 @@
 													<div class="info"><i class="fa icon-center"></i><?php echo showpass_get_event_date($event['ends_on'], $event['timezone'], false);?></div>
 												<?php } ?>
 											<?php } else {?>
-												<div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?></div>
+												<div class="info event-date">
+													<i class="fa fa-calendar icon-center"></i>
+													<div>
+														<?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
+													</div>
+												</div>
 												<div class="info"><i class="fa fa-clock-o icon-center"></i>
 													<?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?> <?php echo showpass_get_timezone_abbr($event['timezone'], false);?>
 												</div>

--- a/plugin/inc/default-list.php
+++ b/plugin/inc/default-list.php
@@ -49,33 +49,30 @@
                   </div>
                 </div>
               </div>
+
+              <!-- Event Date(s) & Badges -->
               <div class="showpass-layout-flex">
+               
                 <div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
                   <div>
-                    <?php if ($event['is_recurring_parent']) { ?>
-                      <?php if (showpass_get_event_date($event['starts_on'], $event['timezone'], false) === showpass_get_event_date($event['ends_on'], $event['timezone'], false)) { ?>
-                        <!-- If recurring children on the same day -->
-                        <div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?></div>
-                        <div class="info"><i class="fa fa-clock-o icon-center"></i>
-                          <?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?> <?php echo showpass_get_timezone_abbr($event['timezone'], false);?>
-                        </div>
-                      <?php } else { ?>
-                        <!-- If recurring children on different days -->
-                        <div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_date($event['ends_on'], $event['timezone'], false);?></div>
-                      <?php } ?>
-                    <?php } else {?>
-                      <div class="info">
-                        <i class="fa fa-calendar icon-center"></i>
-                        <?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
+                    <?php if (!showpass_ticket_sold_out($event) && $event['is_recurring_parent']) : ?>
+                      <div class="info badges">
+                        <span class="badge">
+                          <?php if (showpass_get_event_date($event['starts_on'], $event['timezone']) === showpass_get_event_date($event['ends_on'], $event['timezone'])): ?>
+                            Multiple Times
+                          <?php else: ?>
+                            Multiple Dates
+                          <?php endif ?>
+                        </span>
                       </div>
-                      <div class="info"><i class="fa fa-clock-o icon-center"></i>
-                        <?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?> <?php echo showpass_get_timezone_abbr($event['timezone'], false);?>
-                      </div>
-                    <?php } ?>
+                    <?php endif; ?>
+                    <?= showpass_display_date($event) ?>
                     <div class="info"><i class="fa fa-map-marker icon-center"></i><?php $location = $event['location']; echo $location['name'];?></div>
                   </div>
                 </div>
               </div>
+              <!-- Event Date(s) & Badges -->
+                
               <div class="showpass-layout-flex showpass-list-button-layout">
                 <div class="flex-50 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-left">
                   <div class="showpass-button-full-width-list">
@@ -84,7 +81,7 @@
                         <?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
                       </a>
                     <?php } else { ?>
-                      <a class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event_data['show_eyereturn']) {?> data-eyereturn="<?php echo $event_data['show_eyereturn']; ?>" <?php } ?> <?php if ($event_data['tracking_id']) {?> data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
+                      <a class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if (isset($event_data['show_eyereturn'])) {?> data-eyereturn="<?php echo $event_data['show_eyereturn']; ?>" <?php } ?> <?php if (isset($event_data['tracking_id'])) {?> data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
                         <?php include 'button-verbiage.php'; ?>
                       </a>
                     <?php } ?>

--- a/plugin/inc/default-list.php
+++ b/plugin/inc/default-list.php
@@ -64,7 +64,10 @@
                         <div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_date($event['ends_on'], $event['timezone'], false);?></div>
                       <?php } ?>
                     <?php } else {?>
-                      <div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?></div>
+                      <div class="info">
+                        <i class="fa fa-calendar icon-center"></i>
+                        <?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
+                      </div>
                       <div class="info"><i class="fa fa-clock-o icon-center"></i>
                         <?php echo showpass_get_event_time($event['starts_on'], $event['timezone'], false);?> - <?php echo showpass_get_event_time($event['ends_on'], $event['timezone'], false);?> <?php echo showpass_get_timezone_abbr($event['timezone'], false);?>
                       </div>

--- a/plugin/inc/default-pricing-table.php
+++ b/plugin/inc/default-pricing-table.php
@@ -34,12 +34,7 @@
                   <div class="showpass-layout-flex">
                     <div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
                       <div>
-												<div class="info event-date">
-													<i class="fa fa-calendar icon-center"></i>
-													<div>
-														<?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
-													</div>
-												</div>
+												<?= showpass_display_date($event) ?>
                         <div class="info"><i class="fa fa-map-marker icon-center"></i><?php $location = $event['location']; echo $location['name'];?></div>
                       </div>
                     </div>

--- a/plugin/inc/default-pricing-table.php
+++ b/plugin/inc/default-pricing-table.php
@@ -34,7 +34,12 @@
                   <div class="showpass-layout-flex">
                     <div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
                       <div>
-                        <div class="info"><i class="fa fa-calendar icon-center"></i><?php echo showpass_get_event_date($event['starts_on'], $event['timezone'], false);?></div>
+												<div class="info event-date">
+													<i class="fa fa-calendar icon-center"></i>
+													<div>
+														<?= showpass_display_date($event['starts_on'], $event['ends_on'], $event['timezone']) ?>
+													</div>
+												</div>
                         <div class="info"><i class="fa fa-map-marker icon-center"></i><?php $location = $event['location']; echo $location['name'];?></div>
                       </div>
                     </div>

--- a/plugin/inc/default-pricing-table.php
+++ b/plugin/inc/default-pricing-table.php
@@ -55,7 +55,7 @@
                   <div class="showpass-layout-flex">
                     <div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
                       <div>
-												<?= showpass_display_date($event) ?>
+												<?= showpass_display_date($event, true) ?>
                         <div class="info"><i class="fa fa-map-marker icon-center"></i><?php $location = $event['location']; echo $location['name'];?></div>
                       </div>
                     </div>

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -279,7 +279,7 @@ function showpass_utf8_urldecode($str) {
  * 
  * @return String html date element
  */
-function showpass_display_date ( $event ) {
+function showpass_display_date ( $event, $small = false ) {
   // grab values needed to calculate event times
   $starts_on = $event['starts_on'];
   $ends_on = $event['ends_on'];
@@ -298,25 +298,50 @@ function showpass_display_date ( $event ) {
    * Else just return start day and event times.
    */
   if ($diff_in_hours >= 24) {
-    // start element
-    $starts_date_element = ''
-      .'<div class="info dates">'
-      .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
-      .'<span class="start-date">'
-      .sprintf('<div class="display-inline-block label">Starts: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($starts_on, $timezone))
-      .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
-      .'</span>'
-      .'</div>';
-    // end element
-    $ends_date_element = ''
-      .'<div class="info dates">'
-      .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
-      .'<span class="end-date">'
-      .sprintf('<div class="display-inline-block label">Ends: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($ends_on, $timezone))
-      .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
-      .'</span>'
-      .'</div>';
-    
+    $starts_date_element = '';
+    $ends_date_element = '';
+
+    // small elements used for grids, so text does not get cut off
+    if ($small) {
+      // start element
+      $starts_date_element .= ''
+        .'<div class="info dates">'
+        .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
+        .'<span class="start-date">'
+        .sprintf('<div class="display-inline-block label">Starts: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($starts_on, $timezone))
+        .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
+        .'</span>'
+        .'</div>';
+      // end element
+      $ends_date_element .= ''
+        .'<div class="info dates">'
+        .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
+        .'<span class="end-date">'
+        .sprintf('<div class="display-inline-block label">Ends: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($ends_on, $timezone))
+        .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
+        .'</span>'
+        .'</div>';
+    } else {
+      // start element
+      $starts_date_element .= ''
+        .'<div class="info dates">'
+        .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
+        .'<span class="start-date">'
+        .sprintf('<span>Starts: </span><span class="day">%s</span> ', showpass_get_event_date($starts_on, $timezone))
+        .sprintf('<span class="time">&commat; %s %s</span>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
+        .'</span>'
+        .'</div>';
+      // end element
+      $ends_date_element .= ''
+        .'<div class="info dates">'
+        .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
+        .'<span class="end-date">'
+        .sprintf('<span>Ends: </span><span><span class="day">%s</span> ', showpass_get_event_date($ends_on, $timezone))
+        .sprintf('<span class="time">&commat; %s %s</span>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
+        .'</span>'
+        .'</div>';
+    }
+
     // concat start and end element, then wrap in a div
     return sprintf('%s%s', $starts_date_element , $ends_date_element);
   }

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -275,25 +275,60 @@ function showpass_utf8_urldecode($str) {
 /**
  * Get formatted event dates string.
  * 
- * @param String $start_date - date string
- * @param String $end_date - date string
- * @param String $timezone
+ * @param Object $event
  * 
  * @return String html date element
  */
-function showpass_display_date ($start_date, $end_date, $timezone) {
-  $diff_in_seconds = strtotime($end_date) - strtotime($start_date);
+function showpass_display_date ( $event ) {
+  // grab values needed to calculate event times
+  $starts_on = $event['starts_on'];
+  $ends_on = $event['ends_on'];
+  $timezone = $event['timezone'];
+
+  /**
+   * get difference between start and end times
+   * Used to display multi day vs single day events
+   */
+  $diff_in_seconds = strtotime($ends_on) - strtotime($starts_on);
   $diff_in_hours = $diff_in_seconds / 3600; // 3600 seconds in an hour
 
   /**
    * If the difference between start and end date is > 24 hours,
-   * then return start and end date.
-   * Else just return start date
+   * then display start and end dates/times.
+   * Else just return start day and event times.
    */
   if ($diff_in_hours >= 24) {
-    return sprintf('<span class="start-date multi-date">%s</span><span class="end-date multi-date">%s</span>', showpass_get_event_date($start_date, $timezone), showpass_get_event_date($end_date, $timezone));
+    // start element
+    $starts_date_element = ''
+      .'<div class="info">'
+      .'<i class="fa fa-calendar icon-center"></i>'
+      .'<span class="start-date">'
+      .sprintf('<span>Starts: </span><span>%s</span> ', showpass_get_event_date($starts_on, $timezone))
+      .sprintf('<span>&commat; %s %s</span>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
+      .'</span>'
+      .'</div>';
+    // end element
+    $ends_date_element = ''
+      .'<div class="info">'
+      .'<i class="fa fa-calendar icon-center"></i>'
+      .'<span class="end-date">'
+      .sprintf('<span>Ends: </span><span>%s</span> ', showpass_get_event_date($ends_on, $timezone))
+      .sprintf('<span>&commat; %s %s</span>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
+      .'</span>'
+      .'</div>';
+    
+    // concat start and end element, then wrap in a div
+    return sprintf('%s%s', $starts_date_element , $ends_date_element);
   }
-  return sprintf('<span class="start-date">%s</span>', showpass_get_event_date($start_date, $timezone));
+  
+  // element with start date and event times
+  $element =  ''
+    .'<div>'
+    .sprintf('<div class="info"><i class="fa fa-calendar icon-center"></i><span>%s</span></div>', showpass_get_event_date($starts_on, $timezone))
+    .sprintf('<div class="info"><i class="fa fa-clock-o icon-center"></i><span>%s</span> - <span>%s</span></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_event_time($ends_on, $timezone))
+    .'</div>';
+
+  return $element;
 }
 
 /* Converting date */
@@ -320,7 +355,7 @@ function showpass_get_event_time ($date, $zone) {
     $otherTZ  = new DateTimeZone($zone);
     $datetime->setTimezone($otherTZ);
     if ($format_time == "") {
-      $format_time = "g:iA";
+      $format_time = "g:i A";
     }
     $new_date = $datetime->format($format_time);
     return $new_date;

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -272,6 +272,30 @@ function showpass_utf8_urldecode($str) {
   return html_entity_decode($str,null,'UTF-8');;
 }
 
+/**
+ * Get formatted event dates string.
+ * 
+ * @param String $start_date - date string
+ * @param String $end_date - date string
+ * @param String $timezone
+ * 
+ * @return String html date element
+ */
+function showpass_display_date ($start_date, $end_date, $timezone) {
+  $diff_in_seconds = strtotime($end_date) - strtotime($start_date);
+  $diff_in_hours = $diff_in_seconds / 3600; // 3600 seconds in an hour
+
+  /**
+   * If the difference between start and end date is > 24 hours,
+   * then return start and end date.
+   * Else just return start date
+   */
+  if ($diff_in_hours >= 24) {
+    return sprintf('<span class="start-date multi-date">%s</span><span class="end-date multi-date">%s</span>', showpass_get_event_date($start_date, $timezone), showpass_get_event_date($end_date, $timezone));
+  }
+  return sprintf('<span class="start-date">%s</span>', showpass_get_event_date($start_date, $timezone));
+}
+
 /* Converting date */
 function showpass_get_event_date ($date, $zone) {
 	if ($date && $zone) {

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -300,20 +300,20 @@ function showpass_display_date ( $event ) {
   if ($diff_in_hours >= 24) {
     // start element
     $starts_date_element = ''
-      .'<div class="info">'
-      .'<i class="fa fa-calendar icon-center"></i>'
+      .'<div class="info dates">'
+      .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
       .'<span class="start-date">'
-      .sprintf('<span>Starts: </span><span>%s</span> ', showpass_get_event_date($starts_on, $timezone))
-      .sprintf('<span>&commat; %s %s</span>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
+      .sprintf('<div class="display-inline-block label">Starts: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($starts_on, $timezone))
+      .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
       .'</span>'
       .'</div>';
     // end element
     $ends_date_element = ''
-      .'<div class="info">'
-      .'<i class="fa fa-calendar icon-center"></i>'
+      .'<div class="info dates">'
+      .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
       .'<span class="end-date">'
-      .sprintf('<span>Ends: </span><span>%s</span> ', showpass_get_event_date($ends_on, $timezone))
-      .sprintf('<span>&commat; %s %s</span>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
+      .sprintf('<div class="display-inline-block label">Ends: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($ends_on, $timezone))
+      .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
       .'</span>'
       .'</div>';
     
@@ -325,7 +325,7 @@ function showpass_display_date ( $event ) {
   $element =  ''
     .'<div>'
     .sprintf('<div class="info"><i class="fa fa-calendar icon-center"></i><span>%s</span></div>', showpass_get_event_date($starts_on, $timezone))
-    .sprintf('<div class="info"><i class="fa fa-clock-o icon-center"></i><span>%s</span> - <span>%s</span></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_event_time($ends_on, $timezone))
+    .sprintf('<div class="info"><i class="fa fa-clock-o icon-center"></i><span>%s</span> - <span>%s</span> <span>%s</span></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
     .'</div>';
 
   return $element;


### PR DESCRIPTION
Checks to see if the start date & end date have a difference > 24hrs. 
If so it will display start and end date, otherwise just start date.

---

**Acceptance Testing**

1. Create a multi-date, single date & reoccuring event.
2. Test the following shortcodes to make sure that the event date is displayed properly:
- [showpass_events type="list" detail_page='event-detail' template='grid']
- [showpass_events type="list" detail_page='event-detail' template='list']
- [showpass_events type="detail"]
- [showpass_pricing_table]
