### PR TITLE
Feat/spw 2320 widget description parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ Button to close widget says `Keep Shopping` if true, and `Close` if set to false
 Use the dark theme on the widget, default is the light theme.
 
 
-#### `show_widget_description='true'`
+#### `show_description='true'`
 
 Use this parameter to hide/show the widget description panel.  
 __This will override the admin setting.__

--- a/README.md
+++ b/README.md
@@ -780,7 +780,7 @@ Button to close widget says `Keep Shopping` if true, and `Close` if set to false
 Use the dark theme on the widget, default is the light theme.
 
 
-#### `show_description='true'`
+#### `show_widget_description='true'`
 
 Use this parameter to hide/show the widget description panel.  
 __This will override the admin setting.__

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ This plugin is made for easier access to Showpass Events API data. It allows to 
    2.10. [Event IDs parameter to display specific events](#210-event-ids-parameter)   
    2.11. [Recurring event parameters](#211-recurring-event-parameters)   
    2.12. [Ordering parameter](#212-ordering-parameter)   
-   2.13. [Show parameter & testing](#213-show-parameter-&-testing)   
-   2.14. [Other parameters](#214-other-parameters)   
+   2.13. [Show widget description](#213-show-widget-description)  
+   2.14. [Show parameter & testing](#214-show-parameter-&-testing)   
+   2.15. [Other parameters](#215-other-parameters)   
 3. [Functions](#3-functions)        
    3.1. [Showpass get Event Date](#31-showpass-get-event-date)    
    3.2. [Showpass get Event Time](#32-showpass-get-event-time)    
@@ -217,13 +218,21 @@ ex. `[showpass_events  ordering='-name' type='list' page_size='5' template='defa
 
 This will order events by name starting from Z to A.
 
-## 2.13. Show Parameter & Testing
+
+## 2.13. Show widget description
 
 Use this parameter for testing purposes. Using `show='all'` will show all events you have, regardless of their visibility setting.
 
 ex. `[showpass_events type='list' template='default' detail_page='event-detail' show='all']`
 
-## 2.14. Other Parameters
+## 2.14. Show Parameter & Testing
+
+Use this parameter to hide/show the widget description panel.  
+__This will override the admin setting.__
+
+ex. `[showpass_events type='list' template='default' show_widget_description='true']`
+
+## 2.15. Other Parameters
 
 There are a few other parameters that API can receive and this plugin is compatible for all of these parameters. You can pass it through the URL and you will get the data from API with those parameters.
 
@@ -770,6 +779,12 @@ Button to close widget says `Keep Shopping` if true, and `Close` if set to false
 #### `theme="dark"`
 Use the dark theme on the widget, default is the light theme.
 
+
+#### `show_widget_description='true'`
+
+Use this parameter to hide/show the widget description panel.  
+__This will override the admin setting.__
+
 ## 6.2 Widget Tracking using Affiliate Tracking Links
 
 ### How it Works
@@ -825,6 +840,11 @@ Display specific products by specifying the IDs of the products you would like t
 
 ex. `[showpass_products template="list" product_ids="2,6,7"]`
 
+#### `show_widget_description='true'`
+
+Use this parameter to hide/show the widget description panel.  
+__This will override the admin setting.__
+
 ## 10. Shortcode [showpass_pricing_table]
 Similar to the grid view for the `[showpass_events]` shortcode, but displays events in a grid where all columns are of equal height. Allows you to customize what information is shown and include the event description. You must specify event IDs for events you want to display.
 
@@ -837,3 +857,8 @@ Set `show_event_details='true'` to display the event date, time, and location. B
 
 #### `show_event_description`
 Set `show_event_description='true'` to display the event description. By default this is hidden.
+
+#### `show_widget_description='true'`
+
+Use this parameter to hide/show the widget description panel.  
+__This will override the admin setting.__

--- a/plugin/inc/default-detail.php
+++ b/plugin/inc/default-detail.php
@@ -51,7 +51,10 @@
 									<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
 								</span>
 							<?php } else { ?>
-								<span class="showpass-detail-buy <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['show_eyereturn']) {?> data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
+								<span 
+									class="showpass-detail-buy <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if (isset($event['show_eyereturn'])) {?> data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>
+									data-show-description="<?= $show_widget_description ?>"
+								>
                   <?php include 'button-verbiage.php'; ?>
 	            	</span>
 							<?php } ?>

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -80,7 +80,15 @@
 															<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
 														</a>
 													<?php } else { ?>
-														<a class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
+														<a 
+															class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" 
+															<?php if ($event['external_link']) { ?>
+																href="<?php echo $event['external_link']; ?>"
+															<?php } else { ?>
+																id="<?php echo $event['slug']; ?>"
+															<?php } ?>
+															data-show-description="<?= $show_widget_description ?>"
+														>
                               <?php include 'button-verbiage.php'; ?>
 														</a>
 													<?php } ?>

--- a/plugin/inc/default-list.php
+++ b/plugin/inc/default-list.php
@@ -81,7 +81,21 @@
                         <?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
                       </a>
                     <?php } else { ?>
-                      <a class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event_data['show_eyereturn']) {?> data-eyereturn="<?php echo $event_data['show_eyereturn']; ?>" <?php } ?> <?php if ($event_data['tracking_id']) {?> data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?> <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>"<?php } ?>>
+                      <a 
+                        class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" 
+                        <?php if ($event_data['show_eyereturn']) {?> 
+                          data-eyereturn="<?php echo $event_data['show_eyereturn']; ?>" 
+                        <?php } ?> 
+                        <?php if ($event_data['tracking_id']) {?> 
+                          data-tracking="<?php echo $event_data['tracking_id']; ?>" 
+                        <?php } ?> 
+                        <?php if ($event['external_link']) { ?>
+                          href="<?php echo $event['external_link']; ?>"
+                        <?php } else { ?>
+                          id="<?php echo $event['slug']; ?>"
+                        <?php } ?>
+                        data-show-description="<?= $show_widget_description ?>"
+                      >
                         <?php include 'button-verbiage.php'; ?>
                       </a>
                     <?php } ?>

--- a/plugin/inc/default-pricing-table.php
+++ b/plugin/inc/default-pricing-table.php
@@ -57,7 +57,16 @@
 													<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
 												</a>
 											<?php } else { ?>
-											<a class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"<?php } else { ?>id="<?php echo $event['slug']; ?>" href="#"<?php } ?>>
+											<a 
+												class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" 
+												<?php if ($event['external_link']) { ?>
+													href="<?php echo $event['external_link']; ?>"
+												<?php } else { ?>
+													id="<?php echo $event['slug']; ?>" 
+													href="#"
+												<?php } ?>
+												data-show-description="<?= $show_widget_description ?>"
+											>
                         <?php include 'button-verbiage.php'; ?>
 											</a>
 											<?php } ?>

--- a/plugin/inc/default-product-grid.php
+++ b/plugin/inc/default-product-grid.php
@@ -36,7 +36,11 @@
 										<div class="clearfix showpass-layout-flex showpass-list-button-layout">
 											<div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-left">
 												<div class="showpass-button-full-width-list">
-													<a class="showpass-list-ticket-button showpass-button open-product-widget" id="<?php echo $product['id']; ?>">Buy Now</a>
+													<a 
+														class="showpass-list-ticket-button showpass-button open-product-widget" 
+														id="<?php echo $product['id']; ?>"
+														data-show-description="<?= $show_widget_description ?>"
+													>Buy Now</a>
 												</div>
 											</div>
 										</div>

--- a/plugin/inc/default-product-list.php
+++ b/plugin/inc/default-product-list.php
@@ -42,7 +42,11 @@
 											<div class="clearfix showpass-layout-flex showpass-list-button-layout">
 												<div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-left">
 													<div class="showpass-button-full-width-list">
-														<a class="showpass-list-ticket-button showpass-button open-product-widget" id="<?php echo $product['id']; ?>">Buy Now</a>
+														<a 
+															class="showpass-list-ticket-button showpass-button open-product-widget" 
+															id="<?php echo $product['id']; ?>"
+															data-show-description="<?= $show_widget_description ?>"
+														>Buy Now</a>
 													</div>
 												</div>
 											</div>

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -72,7 +72,8 @@
             var params = {
                 'theme-primary': $('#option_widget_color').val() || '',
                 'keep-shopping': $('#option_keep_shopping').val() || 'true',
-                'theme-dark': $('#option_theme_dark').val() || ''
+                'theme-dark': $('#option_theme_dark').val() || '',
+                'show-description': $('#option_show_widget_description').val() || 'false'
             };
             setTimeout(function() {
                 Cookies.remove('auto');
@@ -87,6 +88,7 @@
                 'theme-primary': $(this).attr('data-color') || $('#option_widget_color').val(),
                 'keep-shopping': $(this).attr('data-shopping') || $('#option_keep_shopping').val(),
                 'theme-dark': $(this).attr('data-theme') || $('#option_theme_dark').val(),
+                'show-description': $(this).attr('data-show-description') || $('#option_show_widget_description').val()
             };
 
             if ($(this).attr('data-tracking')) {
@@ -108,6 +110,7 @@
                 'theme-primary': $('#option_widget_color').val(),
                 'keep-shopping':$('#option_keep_shopping').val() || true,
                 'theme-dark': $('#option_theme_dark').val(),
+                'show-description': $('#option_show_widget_description').val() || 'false'
             };
 
             // Overwrite tracking-id if set in URL
@@ -125,6 +128,7 @@
                 'theme-primary': $(this).attr('data-color') || $('#option_widget_color').val(),
                 'keep-shopping': $(this).attr('data-shopping') || $('#option_keep_shopping').val() || true,
                 'theme-dark': $(this).attr('data-theme') || $('#option_theme_dark').val(),
+                'show-description': $(this).attr('data-show-description') || $('#option_show_widget_description').val() || 'false'
             };
 
             if ($(this).attr('data-tracking')) {
@@ -148,7 +152,8 @@
             showpass.tickets.checkoutWidget({
                 'theme-primary': $('#option_widget_color').val() || '',
                 'keep-shopping': $('#option_keep_shopping').val() || 'true',
-                'theme-dark': $('#option_theme_dark').val() || ''
+                'theme-dark': $('#option_theme_dark').val() || '',
+                'show-description': $('#option_show_widget_description').val() || 'false'
             });
         });
 
@@ -187,7 +192,8 @@
                 var params = {
                     'theme-primary': $(this).attr('data-color') || $('#option_widget_color').val(),
                     'keep-shopping': $(this).attr('data-shopping') || $('#option_keep_shopping').val() || true,
-                    'theme-dark': $(this).attr('data-theme') || $('#option_theme_dark').val()
+                    'theme-dark': $(this).attr('data-theme') || $('#option_theme_dark').val(),
+                    'show-description': $(this).attr('data-show-description') || $('#option_show_widget_description').val() || 'false'
                 };
 
                 if (Cookies.get('affiliate')) {

--- a/plugin/showpass-wordpress-plugin-admin-page.php
+++ b/plugin/showpass-wordpress-plugin-admin-page.php
@@ -32,6 +32,9 @@ You will need to add Organization ID (venue ID) that you want the data from.  EX
         <input type="checkbox" name="option_keep_shopping" value="false" <?php checked('false', get_option('option_keep_shopping'), true); ?>/>
         <label for="main_api_url">Use "Close" verbiage on buttons instead of "Keep Shopping" to close the widget.</label><br/><br/>
 
+        <input type="checkbox" name="option_show_widget_description" value="true" <?php checked('true', get_option('option_show_widget_description'), true); ?>/>
+        <label for="main_api_url">Show Product/Event description tab in the purchase widget.</label><br/><br/>
+
     <?php submit_button(); ?>
 
 </form>

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -32,7 +32,7 @@ function showpass_get_event_data( $atts ) {
 		$type = $atts["type"];
 	} else {
 		$type = "event-list";
-	}
+  }
 
 	if ($type == NULL) {
 		echo "ERROR - Please enter type parameter in shortcode";
@@ -178,12 +178,17 @@ function showpass_get_event_data( $atts ) {
     if ($template == "data") {
       return $data;
     } else {
+      // set shortcode flags for widget
+      if (isset($atts['show_widget_description'])) {
+        $show_widget_description = $atts['show_widget_description'];
+      } else {
+        $show_widget_description = get_option('option_show_widget_description') ? 'true' : 'false';
+      }
 
       ob_start();
       include($filepath);
       $content = ob_get_clean();
       return $content;
-
     }
   }
 }
@@ -253,6 +258,13 @@ function showpass_get_product_data( $atts ) {
 
   if (!is_admin()) {
     $data = call_showpass_api($final_api_url);
+
+    // set shortcode flags for widget
+    if (isset($atts['show_widget_description'])) {
+      $show_widget_description = $atts['show_widget_description'];
+    } else {
+      $show_widget_description = get_option('option_show_widget_description') ? 'true' : 'false';
+    }
 
     if ($template == "data") {
       return $data;
@@ -680,12 +692,27 @@ function showpass_widget_expand($atts, $content = null) {
       $theme_dark = 'false';
     }
 
+    if (isset($atts['show_description'])) {
+      $show_description = $atts['show_description'];
+    } else {
+      $show_description = get_option('option_show_widget_description') ? 'true' : 'false';
+    }
+
     //update to template as needed
     $button = '';
-    $button .= $style.'<div><span id="'.$slug.'" onclick="" class="open-ticket-widget '.$class.'" data-color="'.$widget_color.'" data-shopping="'.$keep_shopping.'" data-theme="'.$theme_dark.'"';
+    $button .= $style.'<div>'
+            .'<span onclick="" '
+            .sprintf('id="%s" ', $slug)
+            .sprintf('class="open-ticket-widget %s" ', $class)
+            .sprintf('data-color="%s" ', $widget_color)
+            .sprintf('data-shopping="%s" ', $keep_shopping)
+            .sprintf('data-theme="%s" ', $theme_dark)
+            .sprintf('data-show-description="%s" ', $show_description);
+
     if ($tracking) {
-      $button .= 'data-tracking="'.$tracking.'"';
+      $button .= sprintf('data-tracking="%s" ', $tracking);
     }
+    
     $button .='"><i class="fa fa-plus" style="margin-right: 10px;"></i>';
     $button .= '<span>'.$label.'</span></div>';
     return $button;
@@ -743,6 +770,13 @@ function wpshp_get_pricing_table( $atts ) {
       }
     }
 
+    // set shortcode flags for widget
+    if (isset($atts['show_widget_description'])) {
+      $show_widget_description = $atts['show_widget_description'];
+    } else {
+      $show_widget_description = get_option('option_show_widget_description') ? 'true' : 'false';
+    }
+
     ob_start();
     include($filepath);
     $content = ob_get_clean();
@@ -783,6 +817,7 @@ add_action( 'init', 'showpass_scripts' );
 
 function showpass_widget_options() {
   echo '<input type="hidden" id="option_keep_shopping" value="'.get_option('option_keep_shopping').'">';
+  echo '<input type="hidden" id="option_show_widget_description" value="'.get_option('option_show_widget_description').'">';
   echo '<input type="hidden" id="option_theme_dark" value="'.get_option('option_theme_dark').'">';
   echo '<input type="hidden" id="option_widget_color" value="'.get_option('option_widget_color').'">';
 }

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -692,8 +692,8 @@ function showpass_widget_expand($atts, $content = null) {
       $theme_dark = 'false';
     }
 
-    if (isset($atts['show_description'])) {
-      $show_description = $atts['show_description'];
+    if (isset($atts['show_widget_description'])) {
+      $show_description = $atts['show_widget_description'];
     } else {
       $show_description = get_option('option_show_widget_description') ? 'true' : 'false';
     }

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -36,6 +36,7 @@ function register_wpshp_settings()
     register_setting('wpshp-settings-group', 'format_time');
     register_setting('wpshp-settings-group', 'option_theme_dark');
     register_setting('wpshp-settings-group', 'option_keep_shopping');
+    register_setting('wpshp-settings-group', 'option_show_widget_description');
 }
 
 /******************************


### PR DESCRIPTION
This feature will allow the user to hide/show the description panel in the widget for both products and tickets.

---

### Acceptance Testing
This feature needs to be tested on the following shortcodes:
- [showpass_events type="list" detail_page='event-detail' template='list']
- [showpass_events type="list" detail_page='event-detail' template='grid']
- [showpass_events type="detail"]
- [showpass_products template="list" page_size="8"]
- [showpass_products template="grid" page_size="8"]
- [showpass_pricing_table]
- [showpass_widget]

#### Testing Steps:
Run through the following steps for each shortcode listed above.

1. Set the `Show Product/Event description tab in the purchase widget.` in admin panel to `true`.
- Visit the corresponding shortcode page
- Click the "Buy" button for an event/product
- Make sure the description panel shows up.
2. Set the `Show Product/Event description tab in the purchase widget.` in admin panel to `false`.
- Visit the corresponding shortcode page
- Click the "Buy" button for an event/product
- Make sure the description panel shows is hidden.
3. Add the appropriate parameter to the shortcode and set it to `true`.
- Visit the corresponding shortcode page
- Click the "Buy" button for an event/product
- Make sure the description panel shows up.
- (This should override the admin setting)
4. Add the appropriate parameter to the shortcode and set it to `false`.
- Visit the corresponding shortcode page
- Click the "Buy" button for an event/product
- Make sure the description panel shows up.
- (This should override the admin setting)

__Note__ the parameter for every shortcode except `[showpass_widget]` is: `show_widget_description='true'`. For `[showpass_widget]` use `show_description='true'`.