### PR TITLE
bugfix: display pagination li elements inline block always

### DIFF
--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -408,17 +408,7 @@ a {
   border-radius: 0;
   padding: 5px 10px;
   font-size: 0.875rem;
-  display: none;
-}
-
-.showpass-pagination li:last-child, .showpass-pagination li:first-child {
   display: inline-block;
-}
-
-@media print, screen and (min-width: 48.75em) {
-  .showpass-pagination li {
-    display: inline-block;
-  }
 }
 
 .showpass-pagination a, .showpass-pagination button {

--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -205,7 +205,7 @@ a:focus {
   text-decoration: none !important;
 }
 
-.product-price {
+.showpass-product-price {
   margin-top: 10px;
 }
 
@@ -217,7 +217,7 @@ a:focus {
     display: block;
     margin-top: 0px;
   }
-  .product-price {
+  .showpass-product-price {
     margin-top: 0px;
   }
 }
@@ -228,12 +228,6 @@ a:focus {
 
 .showpass-button-pull-left {
   justify-content: flex-start;
-}
-
-a {
-  box-shadow: none !important;
-  -webkit-box-shadow: none !important;
-  text-decoration: none;
 }
 
 .showpass-list-button-layout{
@@ -528,7 +522,7 @@ a {
   text-align: center;
 }
 
-a {
+.showpass-flex-box a {
   box-shadow: none !important;
   -webkit-box-shadow: none !important;
   text-decoration: none;

--- a/plugin/inc/default-product-grid.php
+++ b/plugin/inc/default-product-grid.php
@@ -44,8 +44,8 @@
 							<div class="showpass-full-width">
 								<div class="showpass-layout-flex">
 									<div class="flex-100 showpass-flex-column showpass-no-border">
-										<div class="product-price"><?php if ($product['product_attributes']) : ?><small class="showpass-price-display"><?php echo showpass_get_product_price_range($product['product_attributes']);?> <?php echo $product['currency']; ?></small><?php endif; ?></div>
-										<div class="product-price"><?php if (!$product['product_attributes']) : ?><small class="showpass-price-display"> No Items Available</small><?php endif; ?></div>
+										<div class="showpass-product-price"><?php if ($product['product_attributes']) : ?><small class="showpass-price-display"><?php echo showpass_get_product_price_range($product['product_attributes']);?> <?php echo $product['currency']; ?></small><?php endif; ?></div>
+										<div class="showpass-product-price"><?php if (!$product['product_attributes']) : ?><small class="showpass-price-display"> No Items Available</small><?php endif; ?></div>
                   </div>
 								</div>
 								<div class="showpass-layout-flex">

--- a/plugin/inc/default-product-list.php
+++ b/plugin/inc/default-product-list.php
@@ -36,13 +36,13 @@
 								<div class="showpass-space-between showpass-full-width showpass-layout-fill">
 									<div class="showpass-layout-flex">
 										<div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border">
-											<div class="product-price"><?php if ($product['product_attributes']) : ?>
+											<div class="showpass-product-price"><?php if ($product['product_attributes']) : ?>
                         <small class="showpass-price-display">
                           <?php echo showpass_get_product_price_range($product['product_attributes']);?>
                           <?php if (showpass_get_product_price_range($product['product_attributes']) != 'FREE') { echo $product['currency']; } ?>
                         </small><?php endif; ?>
                       </div>
-	                    <div class="product-price"><?php if (!$product['product_attributes']) : ?><small class="showpass-price-display"> No Items Available</small><?php endif; ?></div>
+	                    <div class="showpass-product-price"><?php if (!$product['product_attributes']) : ?><small class="showpass-price-display"> No Items Available</small><?php endif; ?></div>
 	                  </div>
 									</div>
 									<div class="showpass-layout-flex">

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -286,11 +286,12 @@ function showpass_utf8_urldecode($str) {
  * 
  * @return String html date element
  */
-function showpass_display_date ( $event, $small = false ) {
+function showpass_display_date ($event, $small = false) {
   // grab values needed to calculate event times
   $starts_on = $event['starts_on'];
   $ends_on = $event['ends_on'];
   $timezone = $event['timezone'];
+  $recurring = $event['is_recurring_parent'];
 
   /**
    * get difference between start and end times
@@ -315,18 +316,26 @@ function showpass_display_date ( $event, $small = false ) {
         .'<div class="info dates">'
         .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
         .'<span class="start-date">'
-        .sprintf('<div class="display-inline-block label">Starts: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($starts_on, $timezone))
-        .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
-        .'</span>'
-        .'</div>';
+        .sprintf('<div class="display-inline-block label">Starts: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($starts_on, $timezone));
+        if (!$recurring) {
+          $starts_date_element .= sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone));
+        } else {
+          $starts_date_element .= '</div>';
+        }
+        $starts_date_element .= '</span>'
+          .'</div>';
       // end element
       $ends_date_element .= ''
         .'<div class="info dates">'
         .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
         .'<span class="end-date">'
-        .sprintf('<div class="display-inline-block label">Ends: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($ends_on, $timezone))
-        .sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
-        .'</span>'
+        .sprintf('<div class="display-inline-block label">Ends: </div><div class="display-inline-block"><div class="day">%s</div>', showpass_get_event_date($ends_on, $timezone));
+        if (!$recurring) {
+          $ends_date_element .= sprintf('<div class="time">%s %s</div></div>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone));
+        } else {
+          $ends_date_element .= '</div>';
+        }
+        $ends_date_element .= '</span>'
         .'</div>';
     } else {
       // start element
@@ -334,18 +343,22 @@ function showpass_display_date ( $event, $small = false ) {
         .'<div class="info dates">'
         .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
         .'<span class="start-date">'
-        .sprintf('<span>Starts: </span><span class="day">%s</span> ', showpass_get_event_date($starts_on, $timezone))
-        .sprintf('<span class="time">&commat; %s %s</span>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone))
-        .'</span>'
+        .sprintf('<span>Starts: </span><span class="day">%s</span> ', showpass_get_event_date($starts_on, $timezone));
+      if (!$recurring) {
+        $starts_date_element .= sprintf('<span class="time">&commat; %s %s</span>', showpass_get_event_time($starts_on, $timezone), showpass_get_timezone_abbr($timezone));
+      }
+      $starts_date_element .= '</span>'
         .'</div>';
       // end element
       $ends_date_element .= ''
         .'<div class="info dates">'
         .'<i class="fa fa-calendar icon-center display-inline-block"></i>'
         .'<span class="end-date">'
-        .sprintf('<span>Ends: </span><span><span class="day">%s</span> ', showpass_get_event_date($ends_on, $timezone))
-        .sprintf('<span class="time">&commat; %s %s</span>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone))
-        .'</span>'
+        .sprintf('<span>Ends: </span><span><span class="day">%s</span> ', showpass_get_event_date($ends_on, $timezone));
+      if (!$recurring) {
+        $ends_date_element .= sprintf('<span class="time">&commat; %s %s</span>', showpass_get_event_time($ends_on, $timezone), showpass_get_timezone_abbr($timezone));
+      }
+      $ends_date_element .='</span>'
         .'</div>';
     }
 

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -4,7 +4,7 @@
      Plugin URI: https://github.com/showpass/showpass-wordpress-plugin
      Description: List events, display event details and products. Use the Showpass purchase widget for on site ticket & product purchases all with easy to use shortcodes. See our git repo here for full documentation. https://github.com/showpass/showpass-wordpress-plugin
      Author: Showpass / Up In Code Inc.
-     Version: 3.4.2
+     Version: 3.4.3
      Author URI: https://www.showpass.com
      */
 


### PR DESCRIPTION
`.showpass-pagination` li were `display: none` and only shown after a certain page width.
Made the default `display: inline` so they always show. 