### PR TITLE
SPW-4255 | fixes and shortcode addition to wordpress plugin

### DIFF
--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -54,7 +54,9 @@
 
 /* ---- Grid Overrides ---- */
 
-.showpass-event-card .showpass-event-list .showpass-background-white, .showpass-event-card .showpass-event-layout-list .showpass-background-white{
+.showpass-event-card .showpass-event-list .showpass-background-white,
+.showpass-event-card .showpass-event-layout-list .showpass-background-white,
+.showpass-event-card .showpass-event-grid .showpass-background-white {
   background-color: white;
   color: black;
 }

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -107,9 +107,15 @@
 			script.src = 'https://showpass.com/static/dist/sdk.js';
 			script.onload = function() {
 				const id = embeddedCalendarExists.getAttribute('data-org-id');
-				const params = {
-					'theme-primary': $('#option_widget_color').val()
+				let params = {
+					'theme-primary': $('#option_widget_color').val(),
 				};
+				if (embeddedCalendarExists.getAttribute('data-tags')) {
+					const tags = {
+						tags: embeddedCalendarExists.getAttribute('data-tags')
+					};
+					params = Object.assign(params, tags);
+				}
 				showpass.tickets.mountCalendarWidget(id, params);
 			};
 			document.body.appendChild(script);

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -100,6 +100,21 @@
 			showpass.tickets.calendarWidget(id, params);
 		});
 
+		const embeddedCalendarExists = document.getElementById('showpass-calendar-widget');
+		if (embeddedCalendarExists) {
+			let script = document.createElement("script");
+			script.type = "text/javascript";
+			script.src = 'https://showpass.com/static/dist/sdk.js';
+			script.onload = function() {
+				const id = embeddedCalendarExists.getAttribute('data-org-id');
+				const params = {
+					'theme-primary': $('#option_widget_color').val()
+				};
+				showpass.tickets.mountCalendarWidget(id, params);
+			};
+			document.body.appendChild(script);
+		}
+
         $('body').on('click', '.open-product-widget', function(e) {
             e.preventDefault();
 

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -962,8 +962,11 @@ add_shortcode('showpass_calendar_widget', 'wpshp_calendar_widget');
 function wpshp_embed_calendar($atts, $content = null) {
 	$organization_id = get_option('option_organization_id');
 
+	$tags = isset($atts['tags']) ? $atts['tags']
+								 : null;
+
 	if ($organization_id) {
-		return '<div id="showpass-calendar-widget" data-org-id="'.$organization_id.'"><div>';
+		return '<div id="showpass-calendar-widget" data-org-id="'.$organization_id.'" data-tags="'.$tags.'"><div>';
 	} else {
 		return 'Please add your Showpass Organizer ID to your Wordpress Dashboard.';
 	}

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -958,6 +958,19 @@ function wpshp_calendar_widget($atts, $content = null) {
 
 add_shortcode('showpass_calendar_widget', 'wpshp_calendar_widget');
 
+//[showpass_embed_calendar]
+function wpshp_embed_calendar($atts, $content = null) {
+	$organization_id = get_option('option_organization_id');
+
+	if ($organization_id) {
+		return '<div id="showpass-calendar-widget" data-org-id="'.$organization_id.'"><div>';
+	} else {
+		return 'Please add your Showpass Organizer ID to your Wordpress Dashboard.';
+	}
+}
+
+add_shortcode('showpass_embed_calendar', 'wpshp_embed_calendar');
+
 function showpass_scripts(){
 	if (!is_admin()) {
 		wp_enqueue_style('showpass-style', plugins_url( '/css/showpass-style.css', __FILE__ ), array(), null);

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -4,7 +4,7 @@
      Plugin URI: https://github.com/showpass/showpass-wordpress-plugin
      Description: List events, display event details and products. Use the Showpass purchase widget for on site ticket & product purchases all with easy to use shortcodes. See our git repo here for full documentation. https://github.com/showpass/showpass-wordpress-plugin
      Author: Showpass / Up In Code Inc.
-     Version: 3.6.0
+     Version: 3.6.1
      Author URI: https://www.showpass.com
      */
 


### PR DESCRIPTION
- fixes white background not working in grid view
- adds embedded calendar shortcode, which can be passed tags (categories)

The embedded calendar shortcode requires the sdk.js file, which is currently added to the <head> tag, however it doesn't work unless added after the <head> tag so had to be injected in again before calling `mountCalendarWidget`. Open to suggestions on an alternative to avoid calling sdk.js twice.