### PR TITLE
SPW-4658 | calendar not considering the event year when displaying events

### DIFF
--- a/plugin/js/showpass-calendar.js
+++ b/plugin/js/showpass-calendar.js
@@ -291,7 +291,8 @@
             // Find current week and get start end dates for event query
             // Set proper dates for selecting
             let currentWeek = moment(week).format();
-            let startWeek = moment(currentWeek).startOf('week').toISOString();
+            let startOfWeek = moment(currentWeek).startOf('week').toISOString();
+            let endOfWeek = moment(currentWeek).endOf('week').toISOString();
 
             $('#view-select .month').attr('current_date', moment(currentWeek).startOf('month').format());
             $('#view-select .week, #view-select .day').attr('current_date', moment(currentWeek).startOf('week').format());
@@ -310,7 +311,8 @@
             let hide_children = $('#hide-children').val();
             if (venue) {
                 // set initial URL
-    			let url = "https://www.showpass.com/api/public/events/?venue__in=" + venue + "&page_size=100&starts_on__gte=" + startWeek;
+    			let url = "https://www.showpass.com/api/public/events/?venue__in=" + venue +
+                    "&page_size=100&starts_on__lte=" + endOfWeek + "&ends_on__gte=" + startOfWeek;
                 // if tags param append to url
                 if (tags) {
                     url = url + "&tags=" + tags;

--- a/plugin/js/showpass-calendar.js
+++ b/plugin/js/showpass-calendar.js
@@ -426,7 +426,7 @@
 
             if (venue) {
 
-    			let url = "https://local.showpass.com:9000/api/public/events/?venue__in=" + venue +
+    			let url = "https://www.showpass.com/api/public/events/?venue__in=" + venue +
                     "&page_size=100&starts_on__lte=" + endOfMonth + "&ends_on__gte=" + startOfMonth;
 
                 if (tags) {

--- a/plugin/js/showpass-calendar.js
+++ b/plugin/js/showpass-calendar.js
@@ -400,7 +400,8 @@
             $('.showpass-calendar').addClass('monthly');
 
             let currentMonth = moment('01-' + month + "-" + year, "DD-MM-YYYY").format();
-            let startMonth = moment(currentMonth).startOf('month').toISOString();
+            let startOfMonth = moment(currentMonth).startOf('month').toISOString();
+            let endOfMonth = moment(currentMonth).endOf('month').toISOString();
 
             // Set values for display toggle
             $('#view-select .week').attr('current_date', moment(currentMonth).startOf('week').format());
@@ -425,7 +426,8 @@
 
             if (venue) {
 
-    			let url = "https://www.showpass.com/api/public/events/?venue__in=" + venue + "&page_size=100&starts_on__gte=" + startMonth;
+    			let url = "https://local.showpass.com:9000/api/public/events/?venue__in=" + venue +
+                    "&page_size=100&starts_on__lte=" + endOfMonth + "&ends_on__gte=" + startOfMonth;
 
                 if (tags) {
                     url = url + "&tags=" + tags;

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -2,7 +2,7 @@
 Tags: showpass, events, tickets, sell tickets, event calendar, purchase tickets, custom event pages
 Requires at least: 4.9
 Tested up to: 5.6
-Stable tag: 3.5.0
+Stable tag: 3.6.3
 Requires PHP: 5.4.45
 Contributors: marcshowpass, spapril, spzachary
 

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -4,7 +4,7 @@
      Plugin URI: https://github.com/showpass/showpass-wordpress-plugin
      Description: List events, display event details and products. Use the Showpass purchase widget for on site ticket & product purchases all with easy to use shortcodes. See our git repo here for full documentation. https://github.com/showpass/showpass-wordpress-plugin
      Author: Showpass / Up In Code Inc.
-     Version: 3.6.2
+     Version: 3.6.3
      Author URI: https://www.showpass.com
      */
 


### PR DESCRIPTION
Fixed issue where events from any year were displayed in the calendar view for the current year.
Changed query parameters so that they are similar to the calendar widget params.

Testing:
GIVEN event in 2022
WHEN viewing the calendar
THEN the event does not show up in the month or week or day calendars for 2021