### PR TITLE
SPW-6706 | Wordpress Updates

### DIFF
--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -181,7 +181,6 @@
   display: block;
   text-shadow: none !important;
   box-sizing: border-box;
-  margin-top: 15px;
   text-decoration: none !important;
 }
 
@@ -587,7 +586,7 @@ a:focus {
   box-sizing: border-box !important;
 }
 
-.showpass-detail-buy {
+.showpass-detail-buy a.showpass-list-ticket-button.showpass-button {
   display: block;
   width: 100%;
   margin-right: 0;
@@ -597,14 +596,14 @@ a:focus {
   font-weight: bold !important;
   color: #fefefe;
   text-align: center;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  margin-top: 30px;
-  margin-bottom: 30px;
+  padding-top: 20px !important;
+  padding-bottom: 20px !important;
+  margin-top: 30px !important;
+  margin-bottom: 30px !important;
   border-radius: 4px;
 }
 
-.showpass-detail-buy:hover {
+.showpass-detail-buy a:hover {
   background-color: #921818 !important;
 }
 

--- a/plugin/inc/button-logic.php
+++ b/plugin/inc/button-logic.php
@@ -1,0 +1,17 @@
+<?php if ($event['external_link']) { ?>
+<a class="showpass-list-ticket-button showpass-button no-margin" href="<?php echo $event['external_link']; ?>"
+    target="_blank">
+    <?php include 'button-verbiage.php'; ?>
+</a>
+<?php } else if(showpass_ticket_sold_out($event)) { ?>
+<a class="showpass-list-ticket-button showpass-button showpass-soldout no-margin">
+    <?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
+</a>
+<?php } else { ?>
+<a class="showpass-list-ticket-button showpass-button no-margin <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>"
+    id="<?php echo $event['slug']; ?>" data-show-description="<?= $show_widget_description ?>"
+    <?php if (isset($event_data['tracking_id'])) {?> data-tracking="<?php echo $event_data['tracking_id']; ?>"
+    <?php } ?>>
+    <?php include 'button-verbiage.php'; ?>
+</a>
+<?php } ?>

--- a/plugin/inc/default-detail.php
+++ b/plugin/inc/default-detail.php
@@ -29,20 +29,9 @@
     <div class="flex-container showpass-layout-flex">
         <div class="flex-66 showpass-flex-column showpass-no-border">
             <div class="w100">
-                <?php if(showpass_ticket_sold_out($event)) { ?>
-                <span class="showpass-detail-buy showpass-hide-medium showpass-soldout">
-                    <?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
-                </span>
-                <?php } else { ?>
-                <span
-                    class="showpass-detail-buy showpass-hide-medium <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>"
-                    <?php if (isset($event['show_eyereturn'])) {?>
-                    data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?>
-                    <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"
-                    <?php } else { ?>id="<?php echo $event['slug']; ?>" <?php } ?>>
-                    <?php include 'button-verbiage.php'; ?>
-                </span>
-                <?php } ?>
+                <div class="showpass-detail-buy showpass-hide-medium">
+                    <?php include 'button-logic.php'; ?>
+                </div>
                 <div class="showpass-event-description">
                     <?php echo $event['description'];?>
                 </div>
@@ -85,20 +74,9 @@
                         <?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
                     </div>
                     <?php endif; ?>
-                    <?php if(showpass_ticket_sold_out($event)) {?>
-                    <span class="showpass-detail-buy showpass-soldout">
-                        <?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
-                    </span>
-                    <?php } else { ?>
-                    <span class="showpass-detail-buy <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>"
-                        <?php if (isset($event['show_eyereturn'])) {?>
-                        data-eyereturn="<?php echo $event['show_eyereturn']; ?>" <?php } ?>
-                        <?php if ($event['external_link']) { ?>href="<?php echo $event['external_link']; ?>"
-                        <?php } else { ?>id="<?php echo $event['slug']; ?>" <?php } ?>
-                        data-show-description="<?= $show_widget_description ?>">
-                        <?php include 'button-verbiage.php'; ?>
-                    </span>
-                    <?php } ?>
+                    <div class="showpass-detail-buy">
+                        <?php include 'button-logic.php'; ?>
+                    </div>
                 </div>
                 <div class="text-center showpass-detail-location">
                     <?php $location = $event['location'] ?>

--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -17,161 +17,147 @@
 ?>
 
 <div class="showpass-flex-box">
-	<div class="showpass-layout-flex">
-			<?php
+    <div class="showpass-layout-flex">
+        <?php
 			if ($event_data['count'] > 0) {
 				$events = $event_data['results'];
 				foreach ($events as $key => $event) {
 					// default event link does nothing
 					$event_href = 'javascript:void(0);';
-					// only set link if not sold out
-					if ( !showpass_ticket_sold_out($event) ) {
+                    if (isset($event['external_link'])) {
+                        $event_href = $event['external_link'];
+                    }
+                    // only set link if not sold out
+					else if ( !showpass_ticket_sold_out($event) ) {
 						/**
 						 * if detail_page is setup, then link to the detail page
 						 * otherwise link externally
 						 */
 						if (isset($detail_page)) {
 							$event_href = sprintf('/%s/?slug=%s', $detail_page, $event['slug']);
-						} else if (isset($event['external_link'])) {
-							$event_href = $event['external_link'];
 						}
 					}
-				?>	
-				<div class="showpass-flex-column showpass-no-border showpass-event-card showpass-grid">
-					<div class="showpass-event-grid showpass-layout-flex m15">
-						<div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
-							<a href="<?= $event_href ?>" class="showpass-image ratio banner">
-								<?= isset($event['image_banner']) 
-									? $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'title' => $event['name'], 'breakpoints' => $image_breakpoints]) 
-									: sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
-						 		?>
-							</a>
-						</div>
-						<div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white">
-							<div class="showpass-full-width">
-								<!-- Ticket Pricing -->
-								<div class="showpass-layout-flex">
-									<div class="flex-100 showpass-flex-column showpass-no-border">
-										<?php if (!showpass_ticket_sold_out($event)) : ?>
-											<small class="showpass-price-display">
-												<?php if (!$event['is_recurring_parent']) { ?>
-													<?php echo showpass_get_price_range($event['ticket_types']);?>
-													<?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
-												<?php } ?>
-											</small>
-										<?php endif; ?>
-									</div>
-								</div>
-								<!-- Ticket Pricing -->
-								
-								<!-- Event Name -->
-								<div class="showpass-layout-flex">
-									<div class="flex-100 showpass-flex-column showpass-no-border showpass-title-wrapper">
-										<div class="showpass-event-title">
-											<?php if ($detail_page) { ?>
-												<h3><a href="/<?php echo $detail_page ?>/?slug=<?php echo $event['slug']; ?>"><?php echo $event['name']; ?></a></h3>
-											<?php } else {?>
-                        <h3>
-                          <a 
-                            <?php if (!$event['external_link']) { ?>class="open-ticket-widget"<?php } ?> 
-                            <?php if ($event['external_link']) { ?>
-                              href="<?php echo $event['external_link']; ?>"
-                            <?php } else { ?>
-                              id="<?php echo $event['slug']; ?>"<?php } ?>
-                              <?php if (isset($event_data['tracking_id'])) {?> data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?>
-                            >
-                              <?php echo $event['name']; ?>
-                          </a>
-                        </h3>
-											<?php } ?>
-										</div>
-									</div>
-								</div>
-								<!-- Event Name -->
-							
-								<!-- Event Date(s) & Badges -->
-								<div class="showpass-layout-flex">
-									<div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
-										<div>
-											<?php if (!showpass_ticket_sold_out($event) && $event['is_recurring_parent']) : ?>
-												<div class="info badges">
-													<span class="badge">
-														<?php if (showpass_get_event_date($event['starts_on'], $event['timezone']) === showpass_get_event_date($event['ends_on'], $event['timezone'])): ?>
-															Multiple Times
-														<?php else: ?>
-															Multiple Dates
-														<?php endif ?>
-													</span>
-												</div>
-											<?php endif; ?>
-											<?= showpass_display_date($event, true) ?>
-										</div>
-									</div>
-								</div>
-								<!-- Event Date(s) & Badges -->
-							</div>
-						</div>
+				?>
+        <div class="showpass-flex-column showpass-no-border showpass-event-card showpass-grid">
+            <div class="showpass-event-grid showpass-layout-flex m15">
+                <div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
+                    <a href="<?= $event_href ?>" class="showpass-image ratio banner">
+                        <?= isset($event['image_banner']) 
+                            ? $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name'], 'title' => $event['name'], 'breakpoints' => $image_breakpoints]) 
+                            : sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
+                        ?>
+                    </a>
+                </div>
+                <div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white">
+                    <div class="showpass-full-width">
+                        <!-- Ticket Pricing -->
+                        <div class="showpass-layout-flex">
+                            <div class="flex-100 showpass-flex-column showpass-no-border">
+                                <?php if (!showpass_ticket_sold_out($event)) : ?>
+                                <small class="showpass-price-display">
+                                    <?php if (!$event['is_recurring_parent']) { ?>
+                                    <?php echo showpass_get_price_range($event['ticket_types']);?>
+                                    <?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
+                                    <?php } ?>
+                                </small>
+                                <?php endif; ?>
+                            </div>
+                        </div>
+                        <!-- Ticket Pricing -->
 
-						<!-- Action Buttons -->
-						<div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white action-bar">
-							<div class="showpass-layout-flex">
-								<div class="showpass-layout-flex showpass-list-button-layout">
-										<div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-left">
-											<div class="showpass-button-full-width-grid">
-												<?php if(showpass_ticket_sold_out($event)) { ?>
-													<a class="showpass-list-ticket-button showpass-button showpass-soldout no-margin">
-														<?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
-													</a>
-												<?php } else { ?>
-													<a 
-														class="showpass-list-ticket-button showpass-button no-margin <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" 
-														<?php if ($event['external_link']) { ?>
-															href="<?php echo $event['external_link']; ?>"
-														<?php } else { ?>
-															id="<?php echo $event['slug']; ?>"
-														<?php } ?>
-														data-show-description="<?= $show_widget_description ?>"
-                            <?php if (isset($event_data['tracking_id'])) {?> data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?>
-													>
-														<?php include 'button-verbiage.php'; ?>
-													</a>
-												<?php } ?>
-											</div>
-										</div>
-									<?php if ($detail_page) {?>
-										<div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-right">
-											<div class="showpass-button-full-width-grid">
-												<a class="showpass-list-ticket-button showpass-button-secondary no-margin" href="/<?php echo $detail_page; ?>/?slug=<?php echo $event['slug']; ?>">More Info</a>
-											</div>
-										</div>
-									<?php } ?>
-								</div>
-							</div>
-						</div>
-						<!-- Action Buttons -->
-					</div>
-				</div>
-			<?php } ?>
-			<?php if ($event_data['num_pages'] > 1) { ?>
-			<div class="flex-100 showpass-flex-column showpass-no-border text-center">
-				<ul class="showpass-pagination mb0 mt30">
-					<?php for ($i = 1; $i <= $event_data['num_pages']; $i++) {
+                        <!-- Event Name -->
+                        <div class="showpass-layout-flex">
+                            <div class="flex-100 showpass-flex-column showpass-no-border showpass-title-wrapper">
+                                <div class="showpass-event-title">
+                                    <?php if ($detail_page) { ?>
+                                    <h3><a
+                                            href="/<?php echo $detail_page ?>/?slug=<?php echo $event['slug']; ?>"><?php echo $event['name']; ?></a>
+                                    </h3>
+                                    <?php } else {?>
+                                    <h3>
+                                        <a <?php if (!$event['external_link']) { ?>class="open-ticket-widget" <?php } ?>
+                                            <?php if ($event['external_link']) { ?>
+                                            href="<?php echo $event['external_link']; ?>" <?php } else { ?>
+                                            id="<?php echo $event['slug']; ?>" <?php } ?>
+                                            <?php if (isset($event_data['tracking_id'])) {?>
+                                            data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?>>
+                                            <?php echo $event['name']; ?>
+                                        </a>
+                                    </h3>
+                                    <?php } ?>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Event Name -->
+
+                        <!-- Event Date(s) & Badges -->
+                        <div class="showpass-layout-flex">
+                            <div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
+                                <div>
+                                    <?php if (!showpass_ticket_sold_out($event) && $event['is_recurring_parent']) : ?>
+                                    <div class="info badges">
+                                        <span class="badge">
+                                            <?php if (showpass_get_event_date($event['starts_on'], $event['timezone']) === showpass_get_event_date($event['ends_on'], $event['timezone'])): ?>
+                                            Multiple Times
+                                            <?php else: ?>
+                                            Multiple Dates
+                                            <?php endif ?>
+                                        </span>
+                                    </div>
+                                    <?php endif; ?>
+                                    <?= showpass_display_date($event, true) ?>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Event Date(s) & Badges -->
+                    </div>
+                </div>
+
+                <!-- Action Buttons -->
+                <div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white action-bar">
+                    <div class="showpass-layout-flex">
+                        <div class="showpass-layout-flex showpass-list-button-layout">
+                            <div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-left">
+                                <div class="showpass-button-full-width-grid">
+                                    <?php include 'button-logic.php'; ?>
+                                </div>
+                            </div>
+                            <?php if ($detail_page) {?>
+                            <div class="flex-50 showpass-flex-column showpass-no-border showpass-button-pull-right">
+                                <div class="showpass-button-full-width-grid">
+                                    <a class="showpass-list-ticket-button showpass-button-secondary no-margin"
+                                        href="/<?php echo $detail_page; ?>/?slug=<?php echo $event['slug']; ?>">More
+                                        Info</a>
+                                </div>
+                            </div>
+                            <?php } ?>
+                        </div>
+                    </div>
+                </div>
+                <!-- Action Buttons -->
+            </div>
+        </div>
+        <?php } ?>
+        <?php if ($event_data['num_pages'] > 1) { ?>
+        <div class="flex-100 showpass-flex-column showpass-no-border text-center">
+            <ul class="showpass-pagination mb0 mt30">
+                <?php for ($i = 1; $i <= $event_data['num_pages']; $i++) {
 						$current = $i == $event_data['page_number'] ? 'class="current"' : '';
 						if ($current != '') { ?>
-							<li <?php echo $current;?>><?php echo $i;?></li>
-						<?php } else { ?>
-						<li><a href="<?php echo showpass_get_events_next_prev($i);?>"><?php echo $i; ?></a></li>
-					<?php } } ?>
-				</ul>
-			</div>
-			<?php } ?>
-		<?php } else { ?>
-				<div class="flex-100">
-					<h1 class="mt0">Sorry, no events found!</h1>
-					<?php if ($_GET) { ?>
-						<a class="back-link" href="/events/">View All Events</a>
-					<?php } ?>
-				</div>
-			<?php } ?>
-	</div>
+                <li <?php echo $current;?>><?php echo $i;?></li>
+                <?php } else { ?>
+                <li><a href="<?php echo showpass_get_events_next_prev($i);?>"><?php echo $i; ?></a></li>
+                <?php } } ?>
+            </ul>
+        </div>
+        <?php } ?>
+        <?php } else { ?>
+        <div class="flex-100">
+            <h1 class="mt0">Sorry, no events found!</h1>
+            <?php if ($_GET) { ?>
+            <a class="back-link" href="/events/">View All Events</a>
+            <?php } ?>
+        </div>
+        <?php } ?>
+    </div>
 </div>

--- a/plugin/inc/default-list.php
+++ b/plugin/inc/default-list.php
@@ -5,13 +5,16 @@
 ?>
 
 <div class="showpass-flex-box">
-	<div class="showpass-layout-flex">
-    <?php
+    <div class="showpass-layout-flex">
+        <?php
     if ($event_data['count'] > 0) {
       $events = $event_data['results'];
       foreach ($events as $key => $event) { 
         // default event link does nothing
         $event_href = 'javascript:void(0);';
+        if (isset($event['external_link'])) {
+            $event_href = $event['external_link'];
+        }
         // only set link if not sold out
         if ( !showpass_ticket_sold_out($event) ) {
           /**
@@ -20,185 +23,158 @@
            */
           if (isset($detail_page)) {
             $event_href = sprintf('/%s/?slug=%s', $detail_page, $event['slug']);
-          } else if (isset($event['external_link'])) {
-            $event_href = $event['external_link'];
           }
         }
       ?>
 
-      <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-event-card">
-        <div class="showpass-event-layout-list showpass-layout-flex m15">
-          <div class="card-image showpass-flex-column list-layout-flex showpass-no-border showpass-no-padding p0">
-            <a 
-              id="<?php echo $event['slug']; ?>"
-              class="showpass-image showpass-hide-mobile ratio full-height <?php if (showpass_ticket_sold_out($event)) echo 'showpass-soldout' ?>" 
-              href="<?= $event_href ?>"
-              <?php if (isset($event_data['tracking_id'])) : ?> 
-                data-tracking="<?php echo $event_data['tracking_id']; ?>" 
-              <?php endif ?> 
-              <?php if (isset($event_data['show_eyereturn'])) : ?> 
-                data-eyereturn="<?= $event_data['show_eyereturn'] ?>" 
-              <?php endif ?>
-            >
-              <?= isset($event['image']) 
+        <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-event-card">
+            <div class="showpass-event-layout-list showpass-layout-flex m15">
+                <div class="card-image showpass-flex-column list-layout-flex showpass-no-border showpass-no-padding p0">
+                    <a id="<?php echo $event['slug']; ?>"
+                        class="showpass-image showpass-hide-mobile ratio full-height <?php if (showpass_ticket_sold_out($event) && !isset($event['external_link'])) echo 'showpass-soldout' ?>"
+                        href="<?= $event_href ?>" <?php if (isset($event_data['tracking_id'])) : ?>
+                        data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php endif ?>
+                        <?php if (isset($event_data['show_eyereturn'])) : ?>
+                        data-eyereturn="<?= $event_data['show_eyereturn'] ?>" <?php endif ?>>
+                        <?= isset($event['image']) 
                 ? $showpass_image_formatter->getResponsiveImage($event['image'], ['alt' => $event['name']]) 
                 : sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-square.jpg', $event['name']);
               ?>
-            </a>
-            <a 
-              id="<?php echo $event['slug']; ?>"
-              class="showpass-image showpass-hide-large ratio banner <?php if (showpass_ticket_sold_out($event)) echo 'showpass-soldout' ?>" 
-              href="<?= $event_href ?>"
-              <?php if (isset($event_data['tracking_id'])) : ?> 
-                data-tracking="<?php echo $event_data['tracking_id']; ?>" 
-              <?php endif ?> 
-              <?php if (isset($event_data['show_eyereturn'])) : ?> 
-                data-eyereturn="<?= $event_data['show_eyereturn'] ?>" 
-              <?php endif ?>
-            >
-              <?= isset($event['image_banner']) 
+                    </a>
+                    <a id="<?php echo $event['slug']; ?>"
+                        class="showpass-image showpass-hide-large ratio banner <?php if (showpass_ticket_sold_out($event) && !isset($event['external_link'])) echo 'showpass-soldout' ?>"
+                        href="<?= $event_href ?>" <?php if (isset($event_data['tracking_id'])) : ?>
+                        data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php endif ?>
+                        <?php if (isset($event_data['show_eyereturn'])) : ?>
+                        data-eyereturn="<?= $event_data['show_eyereturn'] ?>" <?php endif ?>>
+                        <?= isset($event['image_banner']) 
                 ? $showpass_image_formatter->getResponsiveImage($event['image_banner'], ['alt' => $event['name']]) 
                 : sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $event['name']);
               ?>
-            </a>
-          </div>
-          <div class="list-info showpass-flex-column list-layout-flex showpass-no-border showpass-background-white">
-            <div class="showpass-space-between showpass-full-width showpass-layout-fill">
-              <div class="showpass-layout-flex">
-                <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border">
-                  <div>
-                    <?php if (!showpass_ticket_sold_out($event)) : ?>
-                      <small class="showpass-price-display">
-                        <?php if (!$event['is_recurring_parent']) { ?>
-                          <?php echo showpass_get_price_range($event['ticket_types']);?>
-                          <?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
-                        <?php } ?>
-                      </small>
-                    <?php endif; ?>
-                  </div>
+                    </a>
                 </div>
-              </div>
-              <div class="showpass-layout-flex">
-                <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-title-wrapper">
-                  <div class="showpass-event-title">
-                    <?php if ($detail_page) { ?>
-                      <h3><a href="/<?php echo $detail_page ?>/?slug=<?php echo $event['slug']; ?>"><?php echo $event['name']; ?></a></h3>
-                    <?php } else {?>
-                      <h3>
-                        <a 
-                          <?php if (!$event['external_link']) { ?>class="open-ticket-widget"<?php } ?> 
-                          <?php if (isset($event_data['show_eyereturn'])) {?> data-eyereturn="<?php echo $event_data['show_eyereturn']; ?>" <?php } ?> 
-                          <?php if (isset($event_data['tracking_id'])) {?> data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?> 
-                          <?php if ($event['external_link']) { ?>
-                            href="<?php echo $event['external_link']; ?>"
-                          <?php } else { ?>
-                            id="<?php echo $event['slug']; ?>"
-                          <?php } ?>
-                        >
-                          <?php echo $event['name']; ?>
-                        </a>
-                      </h3>
-                    <?php } ?>
-                  </div>
-                </div>
-              </div>
+                <div
+                    class="list-info showpass-flex-column list-layout-flex showpass-no-border showpass-background-white">
+                    <div class="showpass-space-between showpass-full-width showpass-layout-fill">
+                        <div class="showpass-layout-flex">
+                            <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border">
+                                <div>
+                                    <?php if (!showpass_ticket_sold_out($event)) : ?>
+                                    <small class="showpass-price-display">
+                                        <?php if (!$event['is_recurring_parent']) { ?>
+                                        <?php echo showpass_get_price_range($event['ticket_types']);?>
+                                        <?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
+                                        <?php } ?>
+                                    </small>
+                                    <?php endif; ?>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="showpass-layout-flex">
+                            <div
+                                class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-title-wrapper">
+                                <div class="showpass-event-title">
+                                    <?php if ($detail_page) { ?>
+                                    <h3>
+                                        <a
+                                            href="/<?php echo $detail_page ?>/?slug=<?php echo $event['slug']; ?>"><?php echo $event['name']; ?></a>
+                                    </h3>
+                                    <?php } else {?>
+                                    <h3>
+                                        <a <?php if (!$event['external_link']) { ?>class="open-ticket-widget" <?php } ?>
+                                            <?php if (isset($event_data['show_eyereturn'])) {?>
+                                            data-eyereturn="<?php echo $event_data['show_eyereturn']; ?>" <?php } ?>
+                                            <?php if (isset($event_data['tracking_id'])) {?>
+                                            data-tracking="<?php echo $event_data['tracking_id']; ?>" <?php } ?>
+                                            <?php if ($event['external_link']) { ?>
+                                            href="<?php echo $event['external_link']; ?>" <?php } else { ?>
+                                            id="<?php echo $event['slug']; ?>" <?php } ?>>
+                                            <?php echo $event['name']; ?>
+                                        </a>
+                                    </h3>
+                                    <?php } ?>
+                                </div>
+                            </div>
+                        </div>
 
-              <!-- Event Date(s) & Badges -->
-              <div class="showpass-layout-flex">
-               
-                <div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
-                  <div class="w100">
-                    <?php if (!showpass_ticket_sold_out($event) && $event['is_recurring_parent']) : ?>
-                      <div class="info badges">
-                        <span class="badge">
-                          <?php if (showpass_get_event_date($event['starts_on'], $event['timezone']) === showpass_get_event_date($event['ends_on'], $event['timezone'])): ?>
-                            Multiple Times
-                          <?php else: ?>
-                            Multiple Dates
-                          <?php endif ?>
-                        </span>
-                      </div>
-                    <?php endif; ?>
-                    <div class="showpass-hide-large">
-                      <?= showpass_display_date($event, true) ?>
+                        <!-- Event Date(s) & Badges -->
+                        <div class="showpass-layout-flex">
+
+                            <div class="flex-100 showpass-flex-column showpass-no-border showpass-detail-event-date">
+                                <div class="w100">
+                                    <?php if (!showpass_ticket_sold_out($event) && $event['is_recurring_parent']) : ?>
+                                    <div class="info badges">
+                                        <span class="badge">
+                                            <?php if (showpass_get_event_date($event['starts_on'], $event['timezone']) === showpass_get_event_date($event['ends_on'], $event['timezone'])): ?>
+                                            Multiple Times
+                                            <?php else: ?>
+                                            Multiple Dates
+                                            <?php endif ?>
+                                        </span>
+                                    </div>
+                                    <?php endif; ?>
+                                    <div class="showpass-hide-large">
+                                        <?= showpass_display_date($event, true) ?>
+                                    </div>
+                                    <div class="showpass-hide-mobile">
+                                        <?= showpass_display_date($event) ?>
+                                    </div>
+                                    <div class="info">
+                                        <div class="info-icon">
+                                            <i class="fa fa-map-marker icon-center"></i>
+                                        </div>
+                                        <div class="info-display">
+                                            <?= $event['location']['name'] ?>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Event Date(s) & Badges -->
+
+                        <div class="showpass-layout-flex showpass-list-button-layout">
+                            <div
+                                class="flex-50 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-left">
+                                <div class="showpass-button-full-width-list">
+                                    <?php include 'button-logic.php'; ?>
+                                </div>
+                            </div>
+                            <?php if ($detail_page) {?>
+                            <div
+                                class="flex-50 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-right">
+                                <div class="showpass-button-full-width-list">
+                                    <a class="showpass-list-ticket-button showpass-button-secondary"
+                                        href="/<?php if($detail_page) { echo $detail_page; } else { echo 'event-detail'; } ?>/?slug=<?php echo $event['slug']; ?>">More
+                                        Info</a>
+                                </div>
+                            </div>
+                            <?php } ?>
+                        </div>
                     </div>
-                    <div class="showpass-hide-mobile">
-                      <?= showpass_display_date($event) ?>
-                    </div>
-                    <div class="info">
-                      <div class="info-icon">
-                        <i class="fa fa-map-marker icon-center"></i>
-                      </div>
-                      <div class="info-display">
-                        <?= $event['location']['name'] ?>
-                      </div>
-                     </div>
-                  </div>
                 </div>
-              </div>
-              <!-- Event Date(s) & Badges -->
-                
-              <div class="showpass-layout-flex showpass-list-button-layout">
-                <div class="flex-50 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-left">
-                  <div class="showpass-button-full-width-list">
-                    <?php if(showpass_ticket_sold_out($event)) : ?>
-                      <a class="showpass-list-ticket-button showpass-button showpass-soldout">
-                        <?php echo($event['inventory_sold_out'] || $event['sold_out'] ? 'SOLD OUT' : 'NOT AVAILABLE'); ?>
-                      </a>
-                    <?php else:  ?>
-                      <a 
-                        class="showpass-list-ticket-button showpass-button <?php if (!$event['external_link']) echo 'open-ticket-widget' ?>" 
-                        <?php if (isset($event_data['tracking_id'])) :?> 
-                          data-tracking="<?= $event_data['tracking_id']; ?>" 
-                        <?php endif ?> 
-                        <?php if ($event['external_link']) : ?>
-                          href="<?php echo $event['external_link']; ?>"
-                        <?php else : ?>
-                          id="<?php echo $event['slug']; ?>"
-                        <?php endif ?>
-                        <?php if (isset($event_data['show_eyereturn'])) :?> 
-                          data-eyereturn="<?= $event_data['show_eyereturn']; ?>"
-                        <?php endif ?>
-                        data-show-description="<?= $show_widget_description ?>"
-                      >
-                        <?php include 'button-verbiage.php'; ?>
-                      </a>
-                    <?php endif ?>
-                  </div>
-                </div>
-                <?php if ($detail_page) {?>
-                  <div class="flex-50 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-right">
-                    <div class="showpass-button-full-width-list">
-                      <a class="showpass-list-ticket-button showpass-button-secondary" href="/<?php if($detail_page) { echo $detail_page; } else { echo 'event-detail'; } ?>/?slug=<?php echo $event['slug']; ?>">More Info</a>
-                    </div>
-                  </div>
-                <?php } ?>
-              </div>
             </div>
-          </div>
         </div>
-      </div>
-    <?php } ?>
-    <?php if ($event_data['num_pages'] > 1) { ?>
-    <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border text-center">
-      <ul class="showpass-pagination mb0 mt30">
-        <?php for ($i = 1; $i <= $event_data['num_pages']; $i++) {
+        <?php } ?>
+        <?php if ($event_data['num_pages'] > 1) { ?>
+        <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border text-center">
+            <ul class="showpass-pagination mb0 mt30">
+                <?php for ($i = 1; $i <= $event_data['num_pages']; $i++) {
           $current = $i == $event_data['page_number'] ? 'class="current"' : '';
           if ($current != '') { ?>
-            <li <?php echo $current;?>><?php echo $i;?></li>
-          <?php } else { ?>
-          <li><a href="<?php echo showpass_get_events_next_prev($i);?>"><?php echo $i; ?></a></li>
-        <?php } } ?>
-      </ul>
-    </div>
-    <?php } ?>
-    <?php } else { ?>
-      <div class="flex-100">
-        <h1 class="mt0">Sorry, no events found!</h1>
-        <?php if ($_GET) { ?>
-          <a class="back-link" href="/events/">View All Events</a>
+                <li <?php echo $current;?>><?php echo $i;?></li>
+                <?php } else { ?>
+                <li><a href="<?php echo showpass_get_events_next_prev($i);?>"><?php echo $i; ?></a></li>
+                <?php } } ?>
+            </ul>
+        </div>
         <?php } ?>
-      </div>
-    <?php } ?>
-	</div>
+        <?php } else { ?>
+        <div class="flex-100">
+            <h1 class="mt0">Sorry, no events found!</h1>
+            <?php if ($_GET) { ?>
+            <a class="back-link" href="/events/">View All Events</a>
+            <?php } ?>
+        </div>
+        <?php } ?>
+    </div>
 </div>

--- a/plugin/js/showpass-beta-sdk.js
+++ b/plugin/js/showpass-beta-sdk.js
@@ -1,0 +1,20 @@
+(function(window, document, src) {
+    var config = window.__shwps;
+    if (typeof config === "undefined") {
+        config = function() {
+            config.c(arguments)
+        };
+        config.q = [];
+        config.c = function(args) {
+            config.q.push(args)
+        };
+        window.__shwps = config;
+
+        var s = document.createElement('script');
+        s.type = 'text/javascript';
+        s.async = true;
+        s.src = src;
+        var x = document.getElementsByTagName('script')[0];
+        x.parentNode.insertBefore(s, x);
+    }
+})(window, document, 'https://beta.showpass.com/static/dist/sdk.js');

--- a/plugin/js/showpass-calendar.js
+++ b/plugin/js/showpass-calendar.js
@@ -1,6 +1,14 @@
 (function($) {
 
-    $(window).ready(function() {
+    $(window).ready(function () {
+        
+        let apiURL = 'https://www.showpass.com/api'
+
+        let useBeta = $('#option_use_showpass_beta').val();
+
+        if (useBeta) {
+            apiURL = 'https://beta.showpass.com/api'
+        }
 
         let isMobile = /Mobi/.test(navigator.userAgent);
 
@@ -145,7 +153,7 @@
             $('.showpass-next-day').attr('data-day', moment(moment(date).format()).add(1, 'day').format('DD-MM-YYYY'));
             if (venue) {
                 // set initial URL
-    			let url = "https://www.showpass.com/api/public/events/?venue__in=" + venue + "&page_size=100&starts_on__gte=" + dayStart + "&starts_on__lt=" + dayEnd;
+    			let url = apiURL + "/public/events/?venue__in=" + venue + "&page_size=100&starts_on__gte=" + dayStart + "&starts_on__lt=" + dayEnd;
                 // if tags param append to url
                 if (tags) {
                     url = url + "&tags=" + tags;
@@ -311,7 +319,7 @@
             let hide_children = $('#hide-children').val();
             if (venue) {
                 // set initial URL
-    			let url = "https://www.showpass.com/api/public/events/?venue__in=" + venue +
+    			let url = apiURL + "/public/events/?venue__in=" + venue +
                     "&page_size=100&starts_on__lte=" + endOfWeek + "&ends_on__gte=" + startOfWeek;
                 // if tags param append to url
                 if (tags) {
@@ -428,7 +436,7 @@
 
             if (venue) {
 
-    			let url = "https://www.showpass.com/api/public/events/?venue__in=" + venue +
+    			let url = apiURL + "/public/events/?venue__in=" + venue +
                     "&page_size=100&starts_on__lte=" + endOfMonth + "&ends_on__gte=" + startOfMonth;
 
                 if (tags) {

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -248,23 +248,6 @@
 				$('.showpass-cart-button span').html(Cookies.get('cart'));
 			}
 
-			var span = document.createElement('span');
-
-			span.className = 'fa';
-			span.style.display = 'none';
-			document.body.insertBefore(span, document.body.firstChild);
-
-			function css(element, property) {
-				return window.getComputedStyle(element, null).getPropertyValue(property);
-			}
-
-			if (css(span, 'font-family') !== 'FontAwesome') {
-				var headHTML = document.head.innerHTML;
-				headHTML += '<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">';
-				document.head.innerHTML = headHTML;
-			}
-			document.body.removeChild(span);
-
 			/*
 			* Related events select box widget toggle
 			*/

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -2,7 +2,7 @@
 Tags: showpass, events, tickets, sell tickets, event calendar, purchase tickets, custom event pages
 Requires at least: 4.9
 Tested up to: 6.0.2
-Stable tag: 3.6.7
+Stable tag: 3.7.0
 Requires PHP: 5.4.45
 Contributors: marcshowpass, spapril, spzachary
 

--- a/plugin/showpass-wordpress-plugin-admin-page.php
+++ b/plugin/showpass-wordpress-plugin-admin-page.php
@@ -54,8 +54,13 @@ function wpshp_settings_page() {
 
         <input type="checkbox" name="option_disable_verify_ssl" value="true"
             <?php checked('true', get_option('option_disable_verify_ssl'), true); ?> />
-        <label for="main_api_url">Disable SSL verification when connecting to the API..</label><br />
+        <label for="main_api_url">Disable SSL verification when connecting to the API.</label><br />
         <small>Disable to fix Local SSL Expired issue.</small><br /><br />
+
+        <input type="checkbox" name="option_use_showpass_beta" value="true"
+            <?php checked('true', get_option('option_use_showpass_beta'), true); ?> />
+        <label for="main_api_url">Connect to beta.showpass.com</label><br />
+        <small>CAUTION: This is for testing purposes only.</small><br /><br />
 
         <h3>Distribution Partners</h3>
 

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -982,6 +982,7 @@ add_shortcode('showpass_embed_calendar', 'wpshp_embed_calendar');
 
 function showpass_scripts(){
 	if (!is_admin()) {
+		wp_enqueue_style('showpass-font-awesome', 'https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css', array(), null);
 		wp_enqueue_style('showpass-style', plugins_url( '/css/showpass-style.css', __FILE__ ), array(), null);
 		wp_enqueue_style('showpass-flex-box', plugins_url( '/css/showpass-flex-box.css', __FILE__ ), array(), null);
         if (get_option('option_use_showpass_beta')) {
@@ -997,7 +998,7 @@ function showpass_scripts(){
 		wp_enqueue_script('moment-showpass');
 		wp_enqueue_script('moment-timezone-showpass');
 		wp_enqueue_script('js-cookie', plugins_url( '/js/vendor/js.cookie.js', __FILE__ ), array(), '2.2.0', true);
-		wp_enqueue_script('showpass-custom', plugins_url( '/js/showpass-custom.js', __FILE__ ), array('jquery'), '3.6.5', true);
+		wp_enqueue_script('showpass-custom', plugins_url( '/js/showpass-custom.js', __FILE__ ), array('jquery'), '3.7.0', true);
 	}
 }
 

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -3,8 +3,11 @@
 /**************************
 * registering shortcode
 **************************/
-
-define('SHOWPASS_API_URL', 'https://www.showpass.com/api');
+if (get_option('option_use_showpass_beta')) {
+    define('SHOWPASS_API_URL', 'https://beta.showpass.com/api');
+} else {
+    define('SHOWPASS_API_URL', 'https://www.showpass.com/api');
+}
 define('SHOWPASS_ACTUAL_LINK', strtok($_SERVER["REQUEST_URI"],'?'));
 define('SHOWPASS_API_PUBLIC_EVENTS', SHOWPASS_API_URL . '/public/events');
 define('SHOWPASS_API_PUBLIC_PRODUCTS', SHOWPASS_API_URL . '/public/products');
@@ -981,7 +984,11 @@ function showpass_scripts(){
 	if (!is_admin()) {
 		wp_enqueue_style('showpass-style', plugins_url( '/css/showpass-style.css', __FILE__ ), array(), null);
 		wp_enqueue_style('showpass-flex-box', plugins_url( '/css/showpass-flex-box.css', __FILE__ ), array(), null);
-		wp_enqueue_script('showpass-sdk', plugins_url( '/js/showpass-sdk.js', __FILE__ ), array('jquery'), null, true );
+        if (get_option('option_use_showpass_beta')) {
+            wp_enqueue_script('showpass-beta-sdk', plugins_url( '/js/showpass-beta-sdk.js', __FILE__ ), array('jquery'), null, true );
+        } else {
+            wp_enqueue_script('showpass-sdk', plugins_url( '/js/showpass-sdk.js', __FILE__ ), array('jquery'), null, true );
+        }
 		wp_register_script('showpass-calendar-script', plugins_url( '/js/showpass-calendar.js', __FILE__ ), array('jquery'), '1.0.0', true);
 		wp_register_script('moment-showpass', plugins_url( '/js/moment.js', __FILE__ ), array(), '1.0.1', true);
 		wp_register_script('moment-timezone-showpass', plugins_url( '/js/moment-timezone.js', __FILE__ ), array(), '1.0.2', true);
@@ -1002,6 +1009,7 @@ function showpass_widget_options() {
   echo '<input type="hidden" id="option_theme_dark" value="'.get_option('option_theme_dark').'">';
   echo '<input type="hidden" id="option_widget_color" value="'.get_option('option_widget_color').'">';
   echo '<input type="hidden" id="option_showpass_distribution_tracking" value="'.get_option('option_showpass_distribution_tracking').'">';
+  echo '<input type="hidden" id="option_use_showpass_beta" value="'.get_option('option_use_showpass_beta').'">';
 }
 
 add_action( 'wp_footer', 'showpass_widget_options', 100 );

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -4,7 +4,7 @@
      Plugin URI: https://github.com/showpass/showpass-wordpress-plugin
      Description: List events, display event details and products. Use the Showpass purchase widget for on site ticket & product purchases all with easy to use shortcodes. See our git repo here for full documentation. https://github.com/showpass/showpass-wordpress-plugin
      Author: Showpass / Up In Code Inc.
-     Version: 3.6.7
+     Version: 3.7.0
      Author URI: https://www.showpass.com
      */
 
@@ -47,6 +47,7 @@ function register_wpshp_settings() {
 	register_setting('wpshp-settings-group', 'option_keep_shopping');
 	register_setting('wpshp-settings-group', 'option_show_widget_description');
 	register_setting('wpshp-settings-group', 'option_disable_verify_ssl');
+    register_setting('wpshp-settings-group', 'option_use_showpass_beta');
 	register_setting('wpshp-settings-group', 'option_showpass_access_token');
 	register_setting('wpshp-settings-group', 'option_showpass_distribution_tracking');
   	register_setting('wpshp-settings-group', 'option_showpass_default_button_class');


### PR DESCRIPTION
Additions
* added option on Showpass settings to use beta.showpass.com

Fixes
* fixed display when events with external links had no inventory

--

How to test.

Go to the Showpass Settings in admin and check off the use beta checkbox - ensure that api calls direct to beta
Create an event that has an external link, and no inventory - ensure the grid, list and detail views are working correctly and redirecting