### PR TITLE
feat(analytics) | SPW 8277 Add manual GA4 iframe cross-domain

### DIFF
--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -178,7 +178,7 @@
 							let useBeta = $('#option_use_showpass_beta').val();
 							let apiUrl = 'https://www.showpass.com/api/'
 							if (useBeta) {
-								apiUrl = 'https://local.showpass.com/api/'
+								apiUrl = 'https://beta.showpass.com/api/'
 							}
 							const response = await fetch(apiUrl + 'public/events/' + slug + '/')
 							

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -299,6 +299,8 @@
 
 					// For gtag.js (GA4)
 					// We use the gtag's get commands to get the client_id and session_id to decorate the iframe src
+					// This is additional to the analytics.js linker that should already be in place, AND the cross-domain tracking configured on the GA4 property itself
+					// which is for inbound/outbound clicks.
 					// @see https://support.google.com/analytics/answer/10071811?hl=en#zippy=%2Cmanual-setup
 					if (window.gtag && window.dataLayer) {
 						// Get the first available gtag config on the page. This config will be used


### PR DESCRIPTION
### What is the change?

This configures a manual setup of GA4 cross-domain measurement to support our IFrame page views.

### Why is this change being made?

To add additional support to the UA -> GA4 migration.  

For measuring clicks across domains -  we use Google's no-code config for tracking outbound/inbound link clicks to support cross domain measurement, as per Google's [official documentation ](https://support.google.com/analytics/answer/10071811?hl=en)

For measuring pageviews (ie. Iframes) - Our current implementation which uses the analytics.js' linker decorator currently still works. This is added redundancy for GA4 cross-domain measurements using `client_id` and `session_id` as per [Google's documentation](https://support.google.com/analytics/answer/10071811?hl=en#zippy=%2Cmanual-setup).

### How to test
**Code changes are required.**

Prerequisites
- This branch on the web-app https://bitbucket.org/showpass/web-app/pull-requests/4605
- A GA4 property setup on your venue
- A Wordpress site setup locally.  I have written up a detailed doc about setting up your local environment on Coda [here](https://coda.io/d/Technical-Docs_drJmf2Rwhsj/Wordpress-Plugin_sugSC?searchClick=af374cec-d451-42e0-93cc-9d9e71735e80_rJmf2Rwhsj) for a better dev experience
- A wordpress page with a Showpass Plugin shortcode that displays event info pages (ie. `[showpass_events type="list"]`)

**Testing:**

<details>
<summary> Wordpress setup </summary>
- Using the GA4 propery setup on your venue, add the property to your wordpress app. The easiest way I found without largely involving third-parties is using the "WPCode Lite" plugin that lets you add custom code to headers/footers.

- Using the tag instructions set out in your GA4 property's data stream, paste the code as a site header 
![image](https://github.com/showpass/showpass-wordpress-plugin/assets/6688713/be5933ef-d32b-4b6d-81b8-27391778846d)

- Go to `showpass-beta-sdk.js` file and the call for `beta.showpass.com` to `localhost.showpass.com`.  This will point your plugin to your local web-app instance.
<img width="1348" alt="image" src="https://github.com/showpass/showpass-wordpress-plugin/assets/6688713/35bb1f95-96a7-43ae-806f-88ff4afa5ec4">

- Go to `showpass-wordpress-plugin-shortcode.php`
- In the line that defines the `SHOWPASS_API_URL` variable when `option_use_showpass_beta` is enabled, change the URL from `beta.showpass....` to `localhost.showpass....`

<img width="1338" alt="image" src="https://github.com/showpass/showpass-wordpress-plugin/assets/6688713/372d32c1-b21d-4e89-94e6-d6059e114876">

</details>


<details>
<summary> Testing gtag (GA4) cross-domain </summary>

**Testing with both UA decoration and GA4 decoration**
- Open up an incognito tab and open https://tagassistant.google.com . 
- Enter your local wordpress site as a domain, and go to the page where your Showpass plugin shortcodes live. 
- Click on a call to action so that an iframe pops up.
- In the tagassistant page, a banner will display about an "Unknown domain".  Enable it.

![image](https://github.com/showpass/showpass-wordpress-plugin/assets/6688713/8a546d8b-eb76-4959-8ff7-de3ef5ec7bd6)

- The wordpress page will refresh for tagassistant to reload scripts on the page.
- Perform the call to action once again.
- On the tagassistant page, open the very first `Page View` event under the GA4 tag.   Take note of the `Client ID` and the `Session ID`.

![image](https://github.com/showpass/showpass-wordpress-plugin/assets/6688713/c2302df3-16fc-4aeb-945c-73db069ab54d).

- Open up the `Page View` event of the Iframe opening. This will most likely be the latest PageView event.
- The `Client ID` and the `Session ID` should match the first Page View event.  This means that from the wordpress site visit, and the Showpass widget site "visit",  the analytic events are tracked as thought they are the same session.

![image](https://github.com/showpass/showpass-wordpress-plugin/assets/6688713/c10aa1d0-9cb5-4009-950c-a3bab2f5ec0d)

- Ensure that there are no duplicate events for the IFrame. ( _note that youll see a duplicate PageView event for the wordpress page.  This is expected as when you enabled tagassistant to start tracking the showpass.com domain, it refreshed the page therefore triggering a pageview for the wordpress page_ )




Test the following permutations:
- Wordpress GA4 + Showpass GA4
- Wordpress GA4,UA + Showpass GA4,UA
- Wordpress UA + Showpass UA

Also test with GA4 and UA as a connected property and as a non-connected property.  In all scenarios, there should be no duplicate events and client_id and session_id must continue to match!

</details>
