### PR TITLE
feat(wordpress) | show price for recurring events

### DIFF
--- a/plugin/inc/default-grid.php
+++ b/plugin/inc/default-grid.php
@@ -55,10 +55,8 @@
                             <div class="flex-100 showpass-flex-column showpass-no-border">
                                 <?php if (!showpass_ticket_sold_out($event)) : ?>
                                 <small class="showpass-price-display">
-                                    <?php if (!$event['is_recurring_parent']) { ?>
                                     <?php echo showpass_get_price_range($event['ticket_types']);?>
                                     <?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
-                                    <?php } ?>
                                 </small>
                                 <?php endif; ?>
                             </div>

--- a/plugin/inc/default-list.php
+++ b/plugin/inc/default-list.php
@@ -61,10 +61,8 @@
                                 <div>
                                     <?php if (!showpass_ticket_sold_out($event)) : ?>
                                     <small class="showpass-price-display">
-                                        <?php if (!$event['is_recurring_parent']) { ?>
                                         <?php echo showpass_get_price_range($event['ticket_types']);?>
                                         <?php if (showpass_get_price_range($event['ticket_types']) != 'FREE') { echo $event['currency']; } ?>
-                                        <?php } ?>
                                     </small>
                                     <?php endif; ?>
                                 </div>


### PR DESCRIPTION
### What is the change?
 - Show price details for recurring events

### How to test

- Use this doc to set up your dev environment https://coda.io/d/Technical-Docs_drJmf2Rwhsj/Wordpress-Plugin_sugSC?searchClick=af374cec-d451-42e0-93cc-9d9e71735e80_rJmf2Rwhsj#_lu_J4
- add the shortcode [showpass_events type="list"] to your site
- for recurring events, the price should be shown