### PR TITLE
fix(wordpress) | dont crop banner image on detail 

### DIFF
--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -489,11 +489,10 @@ a:focus {
 .showpass-detail-image-container .showpass-detail-image {
   /* object-fit contain fix */
   position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: auto;
-  height: auto;
+  top: 0%;
+  left: 0%;
+  width: 100%;
+  height: 100%;
   min-width: 100%;
   min-height: 100%;
 }


### PR DESCRIPTION
### What is the change

- adjust styling to not crop banner image on detail page

### How to test

Assuming your event is set up already
-  add [showpass_events type="detail"] to a page and add `?slug=<event slug on beta>` to the url for the page, refresh the page
- you should see the detail page for the event
- the banner image should not be cropped in

