### PR TITLE
fix(wordpress) | missing button verbiage options in wordpress plugin

### DIFF
--- a/plugin/inc/button-verbiage.php
+++ b/plugin/inc/button-verbiage.php
@@ -1,17 +1,19 @@
-<?php if ($event['initiate_purchase_button'] === 'ipbd_buy_tickets') { ?>
+<?php if ($event['initiate_purchase_button'] === 'ipbd_buy_tickets'): ?>
   BUY TICKETS
-<?php } else if ($event['initiate_purchase_button'] === 'ipbd_register') { ?>
+<?php elseif ($event['initiate_purchase_button'] === 'ipbd_register'): ?>
   REGISTER
-<?php } else if ($event['initiate_purchase_button'] === 'ipbd_buy_passes') { ?>
+<?php elseif ($event['initiate_purchase_button'] === 'ipbd_buy_passes'): ?>
   BUY PASSES
-<?php } else if ($event['initiate_purchase_button'] === 'ipbd_select_date') { ?>
+<?php elseif ($event['initiate_purchase_button'] === 'ipbd_select_date'): ?>
   SELECT DATE
-<?php } else if ($event['initiate_purchase_button'] === 'ipbd_select_time') { ?>
+<?php elseif ($event['initiate_purchase_button'] === 'ipbd_select_time'): ?>
   SELECT TIME
-<?php } else if ($event['initiate_purchase_button'] === 'ipbd_select_seats') { ?>
-  SELECT SEATS
-<?php } else if ($event['initiate_purchase_button'] === 'ipbd_rsvp') { ?>
+<?php elseif ($event['initiate_purchase_button'] === 'ipbd_rsvp'): ?>
   RSVP
-<?php } else { ?>
+<?php elseif ($event['initiate_purchase_button'] === 'ipbd_get_tickets'): ?>
+  GET TICKETS
+<?php elseif ($event['initiate_purchase_button'] === 'ipbd_select_seats'): ?>
+  SELECT SEATS
+<?php else: ?>
   BUY TICKETS
-<?php } ?>
+<?php endif ?>


### PR DESCRIPTION
Resolves the button verbiage to include all of the verbiage available [here](https://bitbucket.org/showpass/web-app/src/fe8bc761fc10c36dc0a3a9e1781c5e5d7d03f6a2/apps/tickets/constants.py#apps/tickets/constants.py-618:652).