### PR TITLE
chore(analytics) | Improve traffic source retention on cross domain measurements

### DIFF
--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -317,7 +317,8 @@
 					let queryParams = new URLSearchParams(iFrame.src);
 					if (
 						queryParams.get("parent_client_id") ||
-						queryParams.get("parent_session_id")
+						queryParams.get("parent_session_id") ||
+						queryParams.get("parent_document_referrer")
 					) {
 						return;
 					}

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -260,12 +260,12 @@
 				iFrame.src = linker.decorate(iFrame.src);
 			}
 
-			if (typeof document.cookie === 'string' && document.cookie !== '') {
+			if (typeof document.cookie === "string" && document.cookie !== "") {
 				// Get the _ga from cookies and parse it to extract client_id and session_id.
 				// This is used as a fallback for GTM implementations.
 				let cookie = {};
-				document.cookie.split(';').forEach(function(el) {
-					const splitCookie = el.split('=');
+				document.cookie.split(";").forEach(function (el) {
+					const splitCookie = el.split("=");
 					const key = splitCookie[0].trim();
 					const value = splitCookie[1];
 					cookie[key] = value;
@@ -277,13 +277,27 @@
 					const client_id = gaCookie.substring(6); // using the example above, this will return "1194072907.1685136322"
 					const session_id = client_id.split(".")[1]; // ["1194072907", "1685136322"]
 
-					if (!isNaN(Number(client_id)) && !isNaN(Number(session_id))) {
+					if (
+						!isNaN(Number(client_id)) &&
+						!isNaN(Number(session_id))
+					) {
 						let url = new URL(iFrame.src);
-						url.searchParams.append('client_id', client_id);
-						url.searchParams.append('session_id', session_id);
+						url.searchParams.append("parent_client_id", client_id);
+						url.searchParams.append(
+							"parent_session_id",
+							session_id
+						);
 						iFrame.src = url.toString();
 					}
 				}
+			}
+
+			// Pass the parent page's referrer to our iFrame
+			const referrer = document.referrer;
+			if (referrer) {
+				let url = new URL(iFrame.src);
+				url.searchParams.append("parent_document_referrer", referrer);
+				iFrame.src = url.toString();
 			}
 		}
 
@@ -299,7 +313,10 @@
 
 					// if query params already exist, exit
 					let queryParams = new URLSearchParams(iFrame.src);
-					if (queryParams.get('client_id') || queryParams.get('session_id')) {
+					if (
+						queryParams.get("parent_client_id") ||
+						queryParams.get("parent_session_id")
+					) {
 						return;
 					}
 					decorateIframe(iFrame);

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -294,9 +294,14 @@
 
 			// Pass the parent page's referrer to our iFrame
 			const referrer = document.referrer;
+			const location =
+				typeof window !== "undefined" ? window.location.href : "";
 			if (referrer) {
 				let url = new URL(iFrame.src);
-				url.searchParams.append("parent_document_referrer", referrer);
+				url.searchParams.append(
+					"parent_document_referrer",
+					referrer || location
+				);
 				iFrame.src = url.toString();
 			}
 		}

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -293,15 +293,10 @@
 			}
 
 			// Pass the parent page's referrer to our iFrame
-			const referrer = document.referrer;
-			const location =
-				typeof window !== "undefined" ? window.location.href : "";
+			const referrer = document.referrer || "";
 			if (referrer) {
 				let url = new URL(iFrame.src);
-				url.searchParams.append(
-					"parent_document_referrer",
-					referrer || location
-				);
+				url.searchParams.append("parent_document_referrer", referrer);
 				iFrame.src = url.toString();
 			}
 		}

--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -292,7 +292,9 @@
 				}
 			}
 
-			// Pass the parent page's referrer to our iFrame
+			// Pass the parent page's referrer to our iFrame.
+			// When the referrer is unavailable (ie. direct visit), the web-app
+			// should not inject and GA4 defaults to the default behaviour.
 			const referrer = document.referrer || "";
 			if (referrer) {
 				let url = new URL(iFrame.src);

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -2,7 +2,7 @@
 Tags: showpass, events, tickets, sell tickets, event calendar, purchase tickets, custom event pages
 Requires at least: 4.9
 Tested up to: 6.4.3
-Stable tag: 3.8.11
+Stable tag: 3.8.12
 Requires PHP: 5.4.45
 Contributors: marcshowpass, spapril, spzachary, cgarrovillosp
 

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -5,7 +5,7 @@
  Plugin URI: https://github.com/showpass/showpass-wordpress-plugin
  Description: List events, display event details and products. Use the Showpass purchase widget for on site ticket & product purchases all with easy to use shortcodes. See our git repo here for full documentation. https://github.com/showpass/showpass-wordpress-plugin
  Author: Showpass / Up In Code Inc.
- Version: 3.8.11
+ Version: 3.8.12
  Author URI: https://www.showpass.com
  */
 


### PR DESCRIPTION
## What is the change
This aims to mitigate an issue in cross-domain measurements where the original traffic source is not maintained throughout the entire session despite matching client_id/session_id.

I did this by keeping track of the parent documents referrer, which is used by GA4 as the traffic source

## How to test
Use this PR on the web-app https://bitbucket.org/showpass/web-app/pull-requests/6734

GIVEN a site with a different domain than showpass

AND an iframe of showpass displayed through the showpass plugin

WHEN you open up the iframe

THEN you should see in network devtools that the referrer for the first /collect call to [analytics.google.com](http://analytics.google.com/) is that the referrer is the parent domain.



GIVEN a site with a different domain than showpass

AND an iframe of showpass displayed through the showpass plugin

WHEN you visit the site through google search, or through another domain

AND you open up the iframe

THEN you should see in network devtools that the referrer for the first /collect call to [analytics.google.com](http://analytics.google.com/) is that the referrer is the original site you first landed on. For example, exampleA.com → [exampleB.com](http://exampleb.com/) → [showpass.com](http://showpass.com/) → add to cart, the referrer is [exampleA.com](http://examplea.com/).



You can see the field on network devtools /collect call payload under the _dr parameter