### PR TITLE
feat(widget) add membership grid template to wordpress plugin SPW-15304

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ This plugin is made for easier access to Showpass Events API data. It allows to 
 8. [Query Param - ?auto=slug - Automatically Open Showpass Widget](#8-auto-query-parameter)
 9. [Shortcode - [showpass_products]](#9-shortcode-showpass_products)    
    9.1. [Parameters](#91-parameters)  
-10. [Shortcode - [showpass_pricing_table]](#10-shortcode-showpass_pricing_table)  
+10. [Shortcode - [showpass_memberships]](#10-shortcode-showpass_memberships)  
    10.1. [Parameters](#101-parameters)  
-11. [Calendar Widget V2.0](#11-showpass-calendar-widget) 
+11. [Shortcode - [showpass_pricing_table]](#11-shortcode-showpass_pricing_table)  
+   11.1. [Parameters](#111-parameters)  
+12. [Calendar Widget V2.0](#12-showpass-calendar-widget) 
 
 # 1. Admin page
 
@@ -746,7 +748,7 @@ This function generates a responsive image.
 ```
 # 5. Shortcode [showpass_calendar]
 
-_**We recommend using the new [Calendar Widget v2.0](#11-showpass-calendar-widget)**_
+_**We recommend using the new [Calendar Widget v2.0](#12-showpass-calendar-widget)**_
 
 You will need to add just this shortcode `[showpass_calendar]` and you will get complete calendar with all the events from the venue that is set in the admin page. If the venue(Organization ID) is not set, then you will get all events from the API.
 
@@ -910,12 +912,37 @@ ex. `[showpass_products template="list" product_ids="2,6,7"]`
 Use this parameter to hide/show the widget description panel.  
 __This will override the admin setting.__
 
-# 10. Shortcode [showpass_pricing_table]
+# 10. Shortcode [showpass_memberships]
+
+List & sell memberships from your Showpass organization account
+
+`[showpass_memberships template="grid" page_size="8"]`
+
+## 10.1. Parameters
+
+#### `template="grid|data"`
+Set the display layout `Default: grid`
+
+Use the `template="data"` parameter to customize your own template.
+
+#### `page_size="int"`
+Set the number of results per page `Default: 20`
+
+#### `membership_ids`
+Display specific memberships by specifying the IDs of the membership groups you would like to show.
+
+ex. `[showpass_memberships template="grid" membership_ids="2,6,7"]`
+
+#### `show_widget_description='true'`
+Use this parameter to hide/show the widget description panel.  
+__This will override the admin setting.__
+
+# 11. Shortcode [showpass_pricing_table]
 Similar to the grid view for the `[showpass_events]` shortcode, but displays events in a grid where all columns are of equal height. Allows you to customize what information is shown and include the event description. You must specify event IDs for events you want to display.
 
 `[showpass_pricing_table ids="10125,10254,10288"]`
 
-## 10.1. Parameters
+## 11.1. Parameters
 
 #### `show_event_details`
 Set `show_event_details='true'` to display the event date, time, and location. By default these are hidden.
@@ -928,19 +955,19 @@ Set `show_event_description='true'` to display the event description. By default
 Use this parameter to hide/show the widget description panel.  
 __This will override the admin setting.__
 
-# 11. Showpass Calendar Widget
+# 12. Showpass Calendar Widget
 
 The new calendar widget is great for daily time-slot events, and is recommended instead of the `[showpass_calendar]` shortcode
 
 There are two options, you can display a button, to open a calendar in a pop up, or embed the calendar directly into the page
 
-## 11.1. Shortcode `[showpass_calendar_widget]`
+## 12.1. Shortcode `[showpass_calendar_widget]`
 
 This shortcode will display a button to users to open up the calendar in a pop up
 
 `[showpass_calendar_widget label="View Event Calendar" tags="comedy"]`
 
-## 11.1.1 Parameters
+## 12.1.1 Parameters
 ### `label='View Event Calendar'`
 
 Change this parameter to the desired label on the button, if not included the default is Get Tickets.
@@ -949,13 +976,13 @@ Change this parameter to the desired label on the button, if not included the de
 
 Use this parameter to filter by certain categories or tags, remove entirely for all events
 
-## 11.2. Shortcode `[showpass_embed_calendar]`
+## 12.2. Shortcode `[showpass_embed_calendar]`
 
 This shortcode will embed the calendar directly onto the page the user is viewing
 
 Ensure the container in which this is placed is over 1200px wide in order to display properly on desktop
 
-## 11.1.1 Parameters
+## 12.1.1 Parameters
 
 ### `tags='comedy'`
 

--- a/plugin/css/showpass-style.css
+++ b/plugin/css/showpass-style.css
@@ -40,6 +40,19 @@
   box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.3);
 }
 
+.showpass-membership-grid {
+  background: none !important;
+  margin-left: 0px !important;
+  margin-right: 0px !important;
+  margin-bottom: 30px;
+  position: relative;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.3);
+}
+
+.showpass-membership-grid .small {
+  font-size: 16px;
+}
+
 @media screen and (min-width: 600px) {
   .showpass-grid .action-bar {
     position: absolute;
@@ -210,6 +223,10 @@ a:focus {
   margin-top: 10px;
 }
 
+.showpass-membership-price {
+  margin-top: 10px;
+}
+
 @media screen and (max-width: 780px) {
   .showpass-button-full-width-grid{
     width: 100%;
@@ -219,6 +236,9 @@ a:focus {
     margin-top: 0px;
   }
   .showpass-product-price {
+    margin-top: 0px;
+  }
+  .showpass-membership-price {
     margin-top: 0px;
   }
 }
@@ -368,6 +388,10 @@ a:focus {
 }
 
 .showpass-product-grid-title {
+  max-width: 215px !important;
+}
+
+.showpass-membership-grid-title {
   max-width: 215px !important;
 }
 

--- a/plugin/inc/default-membership-grid.php
+++ b/plugin/inc/default-membership-grid.php
@@ -1,0 +1,100 @@
+<?php 
+global $showpass_image_formatter;
+/**
+ * Custom breakpoints for responsive image.
+ * Add max 980-1920 breakpoint, column layout only allows for a max width of 640px.
+ * 600px x 600px is already cached, so use that image.
+ */
+$image_breakpoints = [
+    [600, '(max-width: 1920px) and (min-width: 981px)'],
+    [960, '(max-width: 980px) and (min-width: 781px)'], 
+    [780, '(max-width: 780px) and (min-width: 601px)'], 
+    [600, '(max-width: 600px) and (min-width: 376px)'], 
+    [375, '(max-width: 375px)']
+];
+
+$membership_data = json_decode($data, true);
+?>
+
+<div class="showpass-flex-box">
+    <div class="showpass-layout-flex">
+        <?php
+        $results_length = count($membership_data['results']);
+        if ($results_length > 0) {
+            $memberships = $membership_data['results'];
+            foreach ($memberships as $key => $membership) {
+                ?>
+                <div class="showpass-flex-column showpass-no-border showpass-event-card showpass-grid">
+                    <div class="showpass-membership-grid showpass-layout-flex m15">
+                        <div class="flex-100 showpass-flex-column showpass-no-border showpass-no-padding p0">
+                            <a href="<?= $membership_href ?>" class="showpass-image ratio banner">
+                                <?= isset($membership['image']) 
+                                    ? $showpass_image_formatter->getResponsiveImage($membership['image'], ['alt' => $membership['name'], 'title' => $membership['name'], 'breakpoints' => $image_breakpoints]) 
+                                    : sprintf('<img src="%s" alt="%s" />', plugin_dir_url(__FILE__).'../images/default-banner.jpg', $membership['name']);
+                                ?>
+                            </a>
+                        </div>
+                        <div class="flex-100 showpass-flex-column showpass-no-border showpass-background-white">
+                            <div class="showpass-full-width">
+                                <div class="showpass-layout-flex">
+                                    <div class="flex-100 showpass-flex-column showpass-no-border">
+                                        <div class="showpass-membership-price"><?php if ($membership['membership_levels']) : ?><small class="showpass-price-display"><?php echo showpass_get_product_price_range($membership['membership_levels']);?> <?php echo $membership['currency']; ?></small><?php endif; ?></div>
+                                        <div class="showpass-membership-price"><?php if (!$membership['membership_levels']) : ?><small class="showpass-price-display"> No Items Available</small><?php endif; ?></div>
+                                    </div>
+                                </div>
+                                <div class="showpass-layout-flex">
+                                    <div class="flex-100 showpass-flex-column showpass-no-border showpass-title-wrapper">
+                                        <div class="showpass-event-title showpass-membership-grid-title">
+                                            <h3><a class="open-membership-widget" id="<?php echo $membership['id']; ?>"><?php echo $membership['name']; ?></a></h3>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="showpass-layout-flex">
+                                    <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border">
+                                        <div>
+                                            <div class="text-muted small"><?php $atts = $membership['membership_levels']; echo sizeOf($atts);?> Options Available</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="showpass-showpass-layout-flex">
+                                    <div class="clearfix showpass-layout-flex showpass-list-button-layout">
+                                        <div class="flex-100 showpass-flex-column list-layout-flex showpass-no-border showpass-button-pull-left">
+                                            <div class="showpass-button-full-width-list">
+                                                <a 
+                                                    class="showpass-list-ticket-button showpass-button open-membership-widget" 
+                                                    id="<?php echo $membership['id']; ?>"
+                                                    data-show-description="<?= $show_widget_description ?>"
+                                                >Buy Now</a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <?php } ?>
+            <?php if ($membership_data['num_pages'] > 1) { ?>
+                <div class="flex-100 showpass-flex-column showpass-no-border text-center">
+                    <ul class="showpass-pagination mb0 mt30">
+                        <?php for ($i = 1; $i <= $membership_data['num_pages']; $i++) {
+                            $current = $i == $membership_data['page_number'] ? 'class="current"' : '';
+                            if ($current != '') { ?>
+                                <li <?php echo $current;?>><?php echo $i;?></li>
+                            <?php } else { ?>
+                                <li><a href="<?php echo showpass_get_events_next_prev($i);?>"><?php echo $i; ?></a></li>
+                            <?php } 
+                        } ?>
+                    </ul>
+                </div>
+            <?php } ?>
+        <?php } else { ?>
+            <div class="flex-100">
+                <h1 class="mt0">Sorry, no memberships found!</h1>
+                <?php if ($_GET) { ?>
+                    <a class="back-link" href="/memberships/">View All Memberships</a>
+                <?php } ?>
+            </div>
+        <?php } ?>
+    </div>
+</div>

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -1124,7 +1124,6 @@ function showpass_get_membership_data( $atts ) {
       $template = "default";
     }
 
-    /* Define API endpoint for memberships */
     $final_api_url = SHOWPASS_API_PUBLIC_MEMBERSHIPS;
 
     if ($type == "list") {

--- a/plugin/showpass-wordpress-plugin-shortcode.php
+++ b/plugin/showpass-wordpress-plugin-shortcode.php
@@ -13,6 +13,7 @@ if (get_option('option_use_showpass_beta')) {
 define('SHOWPASS_ACTUAL_LINK', strtok($_SERVER["REQUEST_URI"],'?'));
 define('SHOWPASS_API_PUBLIC_EVENTS', SHOWPASS_API_URL . '/public/events');
 define('SHOWPASS_API_PUBLIC_PRODUCTS', SHOWPASS_API_URL . '/public/products');
+define('SHOWPASS_API_PUBLIC_MEMBERSHIPS', SHOWPASS_API_URL . '/public/memberships/membership-groups');
 define('DEFAULT_BUTTON_VERBIAGE', 'Get Tickets');
 
 /* making connection and taking the data from API */
@@ -1097,3 +1098,81 @@ function showpass_style_function() {
 }
 
 add_action( 'wp_head', 'showpass_style_function', 100 );
+
+/**
+ * Shortcode handler for [showpass_memberships]
+ * Similar to showpass_get_event_data and showpass_get_product_data
+ */
+function showpass_get_membership_data( $atts ) {
+  if (!is_admin()) {
+    /* get Organization ID that is configured in admin Showpass Event API page */
+    $organization_id = get_option('option_organization_id');
+
+    if (isset($atts["type"])) {
+      $type = $atts["type"];
+    } else {
+      $type = "list";
+    }
+
+    if ($type == NULL) {
+      echo "ERROR - Please enter type parameter in shortcode";
+    }
+
+    if (isset($atts["template"])){
+      $template = $atts["template"];
+    } else {
+      $template = "default";
+    }
+
+    /* Define API endpoint for memberships */
+    $final_api_url = SHOWPASS_API_PUBLIC_MEMBERSHIPS;
+
+    if ($type == "list") {
+      $filepath = 'inc/default-membership-grid.php';
+
+      $final_api_url = $final_api_url . '/?venue_id=' . $organization_id;
+      $parameters = $_GET;
+
+      foreach ($parameters as $parameter => $value) {
+        if ($parameter == 'q' || $parameter == 'tags') {
+          $final_api_url .= "&" . $parameter . "=" . showpass_utf8_urldecode($value);
+        } else if ($parameter == 'page_number') {
+          $final_api_url .= "&page=" . $value;
+        } else {
+          $final_api_url .= "&" . $parameter . "=" . $value;
+        }
+      }
+
+      if (isset($atts['page_size'])) {
+        $number_of_memberships_one_page = $atts['page_size'];
+        $final_api_url .= "&page_size=" . $number_of_memberships_one_page;
+      } else {
+        $number_of_memberships_one_page = 8;
+        $final_api_url .= "&page_size=" . $number_of_memberships_one_page;
+      }
+
+      if (isset($atts['membership_ids'])) {
+        $membership_ids = $atts['membership_ids'];
+        $final_api_url .= "&id__in=" . $membership_ids;
+      }
+    }
+
+    $data = call_showpass_api($final_api_url);
+    $memberships = json_decode($data, true)['results'];
+    // set shortcode flags for widget
+    if (isset($atts['show_widget_description'])) {
+      $show_widget_description = $atts['show_widget_description'];
+    } else {
+      $show_widget_description = get_option('option_show_widget_description') ? 'true' : 'false';
+    }
+
+    if ($template == "data") {
+      return $data;
+    } else {      
+      ob_start();
+      include($filepath);
+      $content = ob_get_clean();
+      return $content;
+    }
+  }
+}

--- a/plugin/showpass-wordpress-plugin.php
+++ b/plugin/showpass-wordpress-plugin.php
@@ -26,6 +26,7 @@ add_action('template_redirect', function () {
     $showpass_image_formatter = new Showpass\ImageFormatter();
     add_shortcode('showpass_events', 'showpass_get_event_data');
     add_shortcode('showpass_products', 'showpass_get_product_data');
+    add_shortcode('showpass_memberships', 'showpass_get_membership_data');
     add_shortcode('showpass_calendar', 'showpass_display_calendar');
     add_shortcode('showpass_widget', 'showpass_widget_expand');
     add_shortcode('showpass_pricing_table', 'wpshp_get_pricing_table');


### PR DESCRIPTION
Adds the membership grid template and `[showpass_memberships]` shortcode to the wordpress plugin.
Given that memberships currently do not have a square image, the list template that is available for products and events is not supported since forcing a banner image into a square format could cut off important details in the images.

Otherwise the shortcode behaves the same as the `[showpass_products]` shortcode and opens up the membership widget.