### PR TITLE
update iframe decorator

### DIFF
--- a/plugin/js/showpass-custom.js
+++ b/plugin/js/showpass-custom.js
@@ -1,14 +1,26 @@
 (function ($, window, document) {
-
 	const getParams = (element) => {
 		return {
-			'theme-primary': $(element).attr('data-color') || $('#option_widget_color').val() || '',
-			'keep-shopping': $(element).attr('data-shopping') || $('#option_keep_shopping').val() || 'true',
-			'theme-dark': $(element).attr('data-theme') || $('#option_theme_dark').val() || '',
-			'show-description': $(element).attr('data-show-description') || $('#option_show_widget_description').val() || 'false',
-			'show-specific-tickets': $(element).attr('data-show-specific-tickets') || ''
-		}
-	}
+			"theme-primary":
+				$(element).attr("data-color") ||
+				$("#option_widget_color").val() ||
+				"",
+			"keep-shopping":
+				$(element).attr("data-shopping") ||
+				$("#option_keep_shopping").val() ||
+				"true",
+			"theme-dark":
+				$(element).attr("data-theme") ||
+				$("#option_theme_dark").val() ||
+				"",
+			"show-description":
+				$(element).attr("data-show-description") ||
+				$("#option_show_widget_description").val() ||
+				"false",
+			"show-specific-tickets":
+				$(element).attr("data-show-specific-tickets") || "",
+		};
+	};
 
 	/**
 	 * Fixes issue with showpass object not initialized yet on page load
@@ -27,33 +39,32 @@
 		setTimeout(refresh, 2000);
 	}
 
-	function init () {
-		$(window).on('load', function () {
-
-			showpass.tickets.addCartCountListener(function(count) {
-				let html = '';
+	function init() {
+		$(window).on("load", function () {
+			showpass.tickets.addCartCountListener(function (count) {
+				let html = "";
 				if (count > 0) {
-					html = 'Shopping Cart (' + count + ')';
-					Cookies.set('cart', html);
-					$('.showpass-cart-button span').html(html);
+					html = "Shopping Cart (" + count + ")";
+					Cookies.set("cart", html);
+					$(".showpass-cart-button span").html(html);
 				} else {
-					html = 'Shopping Cart';
-					Cookies.set('cart', html);
-					$('.showpass-cart-button span').html(html);
+					html = "Shopping Cart";
+					Cookies.set("cart", html);
+					$(".showpass-cart-button span").html(html);
 				}
 			});
 
 			// GET QUERY STING
 			function getQueryStrings() {
 				let assoc = {};
-				let decode = function(s) {
+				let decode = function (s) {
 					return decodeURIComponent(s.replace(/\+/g, " "));
 				};
 				let queryString = location.search.substring(1);
-				var keyValues = queryString.split('&');
+				var keyValues = queryString.split("&");
 
 				for (var i in keyValues) {
-					var key = keyValues[i].split('=');
+					var key = keyValues[i].split("=");
 					if (key.length > 1) {
 						assoc[decode(key[0])] = decode(key[1]);
 					}
@@ -64,31 +75,30 @@
 			var qs = getQueryStrings();
 			// SET AFFILIATE COOKIE
 			if (!$.isEmptyObject(qs) && qs.aff) {
-				Cookies.set('affiliate', qs.aff, {
-					expires: 7
+				Cookies.set("affiliate", qs.aff, {
+					expires: 7,
 				});
 			}
 
 			// SET AUTO OPEN COOKIE
 			if (!$.isEmptyObject(qs) && qs.auto) {
-				Cookies.set('auto', qs.auto, {
-					expires: 7
+				Cookies.set("auto", qs.auto, {
+					expires: 7,
 				});
 			}
-
 		});
 
-		$(document).ready(function() {
+		$(document).ready(function () {
 			function getQueryStrings() {
 				var assoc = {};
-				var decode = function(s) {
+				var decode = function (s) {
 					return decodeURIComponent(s.replace(/\+/g, " "));
 				};
 				var queryString = location.search.substring(1);
-				var keyValues = queryString.split('&');
+				var keyValues = queryString.split("&");
 
 				for (var i in keyValues) {
-					var key = keyValues[i].split('=');
+					var key = keyValues[i].split("=");
 					if (key.length > 1) {
 						assoc[decode(key[0])] = decode(key[1]);
 					}
@@ -101,92 +111,140 @@
 			if (qs.auto) {
 				var slug = qs.auto;
 				let params = {
-					'theme-primary': $('#option_widget_color').val(),
-					'keep-shopping': $('#option_keep_shopping').val(),
-					'show-description': $('#option_show_widget_description').val()
+					"theme-primary": $("#option_widget_color").val(),
+					"keep-shopping": $("#option_keep_shopping").val(),
+					"show-description": $(
+						"#option_show_widget_description"
+					).val(),
 				};
-				setTimeout(function() {
-					Cookies.remove('auto');
+				setTimeout(function () {
+					Cookies.remove("auto");
 					showpass.tickets.eventPurchaseWidget(slug, params);
 				}, 500);
 			}
 
-			$('body').on('click', '.open-calendar-widget', function(e) {
+			$("body").on("click", ".open-calendar-widget", function (e) {
 				e.preventDefault();
 
-				let id = $(this).attr('data-org-id');
+				let id = $(this).attr("data-org-id");
 				let params = {
-					'theme-primary': $(this).attr('data-color') || $('#option_widget_color').val(),
-					'keep-shopping': false,
-					'tags': $(this).attr('data-tags')
+					"theme-primary":
+						$(this).attr("data-color") ||
+						$("#option_widget_color").val(),
+					"keep-shopping": false,
+					tags: $(this).attr("data-tags"),
 				};
 
 				showpass.tickets.calendarWidget(id, params);
 			});
 
 			function initializeShowpassEmbeddedWidgets() {
-				const embeddedCalendarWidget = document.getElementById('showpass-calendar-widget');
+				const embeddedCalendarWidget = document.getElementById(
+					"showpass-calendar-widget"
+				);
 
-				const embeddedCartWidget = document.getElementById('showpass-cart-widget');
-				
+				const embeddedCartWidget = document.getElementById(
+					"showpass-cart-widget"
+				);
+
 				// Check for embedded event/product/membership widgets - look for elements with IDs starting with 'showpass-'
 				// and containing '-widget-'
 				const embeddedPurchaseWidgets = [];
-				document.querySelectorAll('[id^="showpass-"][id*="-widget-"]').forEach(widget => {
-					embeddedPurchaseWidgets.push(widget);
-				});
+				document
+					.querySelectorAll('[id^="showpass-"][id*="-widget-"]')
+					.forEach((widget) => {
+						embeddedPurchaseWidgets.push(widget);
+					});
 
-				if (embeddedCalendarWidget || embeddedPurchaseWidgets.length > 0 || embeddedCartWidget) {
+				if (
+					embeddedCalendarWidget ||
+					embeddedPurchaseWidgets.length > 0 ||
+					embeddedCartWidget
+				) {
 					let script = document.createElement("script");
 					script.type = "text/javascript";
-					script.src = 'https://showpass.com/static/dist/sdk.js';
+					script.src = "https://showpass.com/static/dist/sdk.js";
 
-					let useBeta = $('#option_use_showpass_beta').val();
-					let useDemo = $('#option_use_showpass_demo').val();
+					let useBeta = $("#option_use_showpass_beta").val();
+					let useDemo = $("#option_use_showpass_demo").val();
 					if (useBeta) {
-						script.src = 'https://beta.showpass.com/static/dist/sdk.js';
+						script.src =
+							"https://beta.showpass.com/static/dist/sdk.js";
 					} else if (useDemo) {
-						script.src = 'https://demo.showpass.com/static/dist/sdk.js';
+						script.src =
+							"https://demo.showpass.com/static/dist/sdk.js";
 					}
 
-					script.onload = function() {
+					script.onload = function () {
 						if (embeddedCalendarWidget) {
-							const id = embeddedCalendarWidget.getAttribute('data-org-id');
+							const id =
+								embeddedCalendarWidget.getAttribute(
+									"data-org-id"
+								);
 							let params = {
-								'theme-primary': $('#option_widget_color').val(),
+								"theme-primary": $(
+									"#option_widget_color"
+								).val(),
 							};
-							if (embeddedCalendarWidget.getAttribute('data-tags')) {
+							if (
+								embeddedCalendarWidget.getAttribute("data-tags")
+							) {
 								const tags = {
-									tags: embeddedCalendarWidget.getAttribute('data-tags')
+									tags: embeddedCalendarWidget.getAttribute(
+										"data-tags"
+									),
 								};
 								params = Object.assign(params, tags);
 							}
-							showpass.tickets.calendarWidget(id, params, 'showpass-calendar-widget');
+							showpass.tickets.calendarWidget(
+								id,
+								params,
+								"showpass-calendar-widget"
+							);
 						}
 
 						if (embeddedCartWidget) {
 							let params = {
-								'theme-primary': $('#option_widget_color').val() || '',
-								'keep-shopping': $('#option_keep_shopping').val() || 'true',
-								'theme-dark': $('#option_theme_dark').val() || '',
+								"theme-primary":
+									$("#option_widget_color").val() || "",
+								"keep-shopping":
+									$("#option_keep_shopping").val() || "true",
+								"theme-dark":
+									$("#option_theme_dark").val() || "",
 							};
-							showpass.tickets.checkoutWidget(params, 'showpass-cart-widget');
+							showpass.tickets.checkoutWidget(
+								params,
+								"showpass-cart-widget"
+							);
 						}
 
 						if (embeddedPurchaseWidgets.length > 0) {
-							embeddedPurchaseWidgets.forEach(function(widget) {
-								const slug = widget.getAttribute('data-slug');
-								const widgetType = widget.getAttribute('data-type') || 'event'; // Default to event if not specified
-								
+							embeddedPurchaseWidgets.forEach(function (widget) {
+								const slug = widget.getAttribute("data-slug");
+								const widgetType =
+									widget.getAttribute("data-type") || "event"; // Default to event if not specified
+
 								let params = getParams(widget);
-								
-								if (widgetType === 'product') {
-									showpass.tickets.productPurchaseWidget(slug, params, widget.id);
-								} else if (widgetType === 'membership') {
-									showpass.tickets.membershipPurchaseWidget(slug, params, widget.id);
+
+								if (widgetType === "product") {
+									showpass.tickets.productPurchaseWidget(
+										slug,
+										params,
+										widget.id
+									);
+								} else if (widgetType === "membership") {
+									showpass.tickets.membershipPurchaseWidget(
+										slug,
+										params,
+										widget.id
+									);
 								} else {
 									// Default to event widget
-									showpass.tickets.eventPurchaseWidget(slug, params, widget.id);
+									showpass.tickets.eventPurchaseWidget(
+										slug,
+										params,
+										widget.id
+									);
 								}
 							});
 						}
@@ -198,158 +256,163 @@
 			initializeShowpassEmbeddedWidgets();
 
 			const openShowpassWidget = (slug, params, widgetType) => {
-				if (widgetType === 'product') {
+				if (widgetType === "product") {
 					showpass.tickets.productPurchaseWidget(slug, params);
-				} else if (widgetType === 'membership') {
+				} else if (widgetType === "membership") {
 					showpass.tickets.membershipPurchaseWidget(slug, params);
 				} else {
 					// Default to event widget
 					showpass.tickets.eventPurchaseWidget(slug, params);
 				}
-			}
+			};
 
-			$('body').on('click', '.open-membership-widget', function(e) {
+			$("body").on("click", ".open-membership-widget", function (e) {
 				e.preventDefault();
 
-				let id = $(this).attr('id');
+				let id = $(this).attr("id");
 				let params = getParams(this);
 
-				if ($(this).attr('data-tracking')) {
-					params['tracking-id'] = $(this).attr('data-tracking');
+				if ($(this).attr("data-tracking")) {
+					params["tracking-id"] = $(this).attr("data-tracking");
 				}
 
 				// Overwrite tracking-id if set in URL
-				if (Cookies.get('affiliate')) {
-					params['tracking-id'] = Cookies.get('affiliate');
+				if (Cookies.get("affiliate")) {
+					params["tracking-id"] = Cookies.get("affiliate");
 				}
 
-				openShowpassWidget(id, params, 'membership');
+				openShowpassWidget(id, params, "membership");
 			});
 
-			$('body').on('click', '.open-ticket-widget', function (e) {
+			$("body").on("click", ".open-ticket-widget", function (e) {
 				e.preventDefault();
 
-				let slug = $(this).attr('id');
+				let slug = $(this).attr("id");
 				let params = getParams(this);
 
-				if ($(this).attr('data-tracking')) {
-					params['tracking-id'] = $(this).attr('data-tracking');
+				if ($(this).attr("data-tracking")) {
+					params["tracking-id"] = $(this).attr("data-tracking");
 				}
 
 				// Overwrite tracking-id if set in URL
-				if (Cookies.get('affiliate')) {
-					params['tracking-id'] = Cookies.get('affiliate');
+				if (Cookies.get("affiliate")) {
+					params["tracking-id"] = Cookies.get("affiliate");
 				}
 
-				openShowpassWidget(slug, params, 'event');
+				openShowpassWidget(slug, params, "event");
 			});
 
-			$('body').on('click', '.open-product-widget', function(e) {
+			$("body").on("click", ".open-product-widget", function (e) {
 				e.preventDefault();
 
-				let id = $(this).attr('id');
+				let id = $(this).attr("id");
 				let params = getParams(this);
 
-				if ($(this).attr('data-tracking')) {
-					params['tracking-id'] = $(this).attr('data-tracking');
+				if ($(this).attr("data-tracking")) {
+					params["tracking-id"] = $(this).attr("data-tracking");
 				}
 
 				// Overwrite tracking-id if set in URL
-				if (Cookies.get('affiliate')) {
-					params['tracking-id'] = Cookies.get('affiliate');
+				if (Cookies.get("affiliate")) {
+					params["tracking-id"] = Cookies.get("affiliate");
 				}
 
-				openShowpassWidget(id, params, 'product');
+				openShowpassWidget(id, params, "product");
 			});
 
-			$('body').on('click', 'a[href*="showpass.com"].force-showpass-widget', function(e) {
-				e.preventDefault();
-				
-				let slug;
-				const href = $(this).attr('href');
+			$("body").on(
+				"click",
+				'a[href*="showpass.com"].force-showpass-widget',
+				function (e) {
+					e.preventDefault();
 
-				if (href.includes('/m/')) {
-					// For membership URLs
-					slug = href.split('/m/')[1];
-				} else {
-					try {
-						const url = new URL(href);
-						slug = url.pathname.substring(1); // Remove leading slash
-					} catch (e) {
-						slug = href.split('.com/')[1];
+					let slug;
+					const href = $(this).attr("href");
+
+					if (href.includes("/m/")) {
+						// For membership URLs
+						slug = href.split("/m/")[1];
+					} else {
+						try {
+							const url = new URL(href);
+							slug = url.pathname.substring(1); // Remove leading slash
+						} catch (e) {
+							slug = href.split(".com/")[1];
+						}
 					}
-				}
-				
-				let params = getParams(this);
-				
-				if ($(this).attr('data-tracking')) {
-					params['tracking-id'] = $(this).attr('data-tracking');
-				}
-				
-				// Overwrite tracking-id if set in URL
-				if (Cookies.get('affiliate')) {
-					params['tracking-id'] = Cookies.get('affiliate');
-				}
 
-				let widgetType = 'event';
-				if (href.includes('/m/')) {
-					widgetType = 'membership';
-				}
+					let params = getParams(this);
 
-				if ($(this).attr('data-type')) {
-					widgetType = $(this).attr('data-type');
-				}
-				
-				openShowpassWidget(slug, params, widgetType);
-			});
+					if ($(this).attr("data-tracking")) {
+						params["tracking-id"] = $(this).attr("data-tracking");
+					}
 
-			$('.showpass-cart-button').on('click', function(e) {
+					// Overwrite tracking-id if set in URL
+					if (Cookies.get("affiliate")) {
+						params["tracking-id"] = Cookies.get("affiliate");
+					}
+
+					let widgetType = "event";
+					if (href.includes("/m/")) {
+						widgetType = "membership";
+					}
+
+					if ($(this).attr("data-type")) {
+						widgetType = $(this).attr("data-type");
+					}
+
+					openShowpassWidget(slug, params, widgetType);
+				}
+			);
+
+			$(".showpass-cart-button").on("click", function (e) {
 				e.preventDefault();
 				let params = getParams(this);
 				showpass.tickets.checkoutWidget(params);
 			});
 
-			if (Cookies.get('cart')) {
-				$('.showpass-cart-button span').html(Cookies.get('cart'));
+			if (Cookies.get("cart")) {
+				$(".showpass-cart-button span").html(Cookies.get("cart"));
 			}
 
 			/*
-			* Related events select box widget toggle
-			*/
+			 * Related events select box widget toggle
+			 */
 
-			$('.showpass-date-select').on('change', function(e) {
+			$(".showpass-date-select").on("change", function (e) {
 				var slug = $(this).val();
-				if (slug != '') {
+				if (slug != "") {
 					let params = getParams(this);
 
-					if (Cookies.get('affiliate')) {
-						params['tracking-id'] = Cookies.get('affiliate');
+					if (Cookies.get("affiliate")) {
+						params["tracking-id"] = Cookies.get("affiliate");
 					}
 
 					showpass.tickets.eventPurchaseWidget(slug, params);
 				}
 			});
-
 		});
 
-
 		/**
-		 * Shared function to decorate iframe - we default to cookie version because its more reliable
-		 * @param {object} showpass widget iframe object
+		 * Shared function to decorate iframe - handles both cookie-based tracking and query parameters
+		 * @param {HTMLIFrameElement} iFrame - The iframe element to decorate
 		 */
 		const decorateIframe = (iFrame) => {
-			// For analytics.js (UA)
-			// We use the linker provided by analytics.js to decorate the iframe src
-			let gobj = window[window.GoogleAnalyticsObject];
-			if (gobj) {
-				let tracker = gobj.getAll()[0];
-				let linker = new window.gaplugins.Linker(tracker);
-				iFrame.src = linker.decorate(iFrame.src);
+			if (!iFrame || !iFrame.src) {
+				console.warn("Invalid iframe provided to decorateIframe");
+				return;
 			}
 
+			// Prevent multiple decorations
+			if (iFrame.dataset.decorated) {
+				return;
+			}
+
+			let url = new URL(iFrame.src);
+
+			// 1. Handle cookie-based tracking (GA and Facebook)
 			if (typeof document.cookie === "string" && document.cookie !== "") {
-				// Get the _ga from cookies and parse it to extract client_id and session_id.
-				// This is used as a fallback for GTM implementations.
+				// Parse cookies into an object
 				let cookie = {};
 				document.cookie.split(";").forEach(function (el) {
 					const splitCookie = el.split("=");
@@ -357,78 +420,140 @@
 					const value = splitCookie[1];
 					cookie[key] = value;
 				});
+
 				// Parse the _ga cookie to extract client_id and session_id.
-				// A _ga cookie will look something like GA1.1.1194072907.1685136322
+				// A _ga cookie typically looks like GA1.1.1194072907.1685136322
 				const gaCookie = cookie["_ga"];
 				if (gaCookie) {
-					const client_id = gaCookie.substring(6); // using the example above, this will return "1194072907.1685136322"
+					const client_id = gaCookie.substring(6); // Example: "1194072907.1685136322"
 					const session_id = client_id.split(".")[1]; // ["1194072907", "1685136322"]
 
 					if (
 						!isNaN(Number(client_id)) &&
 						!isNaN(Number(session_id))
 					) {
-						let url = new URL(iFrame.src);
 						url.searchParams.append("parent_client_id", client_id);
 						url.searchParams.append(
 							"parent_session_id",
 							session_id
 						);
-						iFrame.src = url.toString();
+					}
+				}
+
+				// Add fbclid from _fbc cookie if present and properly formatted
+				const fbcCookie = cookie["_fbc"];
+				if (fbcCookie) {
+					const parts = fbcCookie.split(".");
+					// Expecting exactly 4 parts; use the last part as fbclid
+					if (parts.length === 4) {
+						url.searchParams.append("fbclid", parts[3]);
 					}
 				}
 			}
 
-			// Pass the parent page's referrer to our iFrame.
-			// When the referrer is unavailable (ie. direct visit), the web-app
-			// should not inject and GA4 defaults to the default behaviour.
+			// 2. Pass the parent page's referrer to our iFrame
 			const referrer = document.referrer || "";
 			if (referrer) {
-				let url = new URL(iFrame.src);
 				url.searchParams.append("parent_document_referrer", referrer);
-				iFrame.src = url.toString();
 			}
-		}
 
-		/*
-		* Decorate iFrame for GA cross domain tracking
-	    * This only works for pop ups, for embedded calendar we need to use a watcher
-		*/
-		const mutationObserver = new MutationObserver(function(mutations) {
-			mutations.forEach(function(mutation) {
-				if (mutation.target.className.includes('showpass-widget-body') && document) {
+			// 3. Add current page query parameters
+			// This is REQUIRED for the checkout widget to work properly with Affirm redirects
+			const currentUrl = new URL(window.location.href);
+			const queryParams = currentUrl.searchParams;
 
-					let iFrame = document.getElementById('showpass-widget');
-
-					// if query params already exist, exit
-					let queryParams = new URLSearchParams(iFrame.src);
-					if (
-						queryParams.get("parent_client_id") ||
-						queryParams.get("parent_session_id") ||
-						queryParams.get("parent_document_referrer")
-					) {
-						return;
+			if (queryParams.toString()) {
+				queryParams.forEach((value, key) => {
+					// Check if parameter already exists in iframe src to avoid duplicates
+					if (!url.searchParams.has(key)) {
+						url.searchParams.append(key, value);
 					}
-					decorateIframe(iFrame);
-				}
+				});
+			}
+
+			// Update iframe src and mark as decorated
+			iFrame.src = url.toString();
+			iFrame.dataset.decorated = "true";
+
+			console.log(
+				"Decorated iframe with tracking parameters:",
+				url.toString()
+			);
+		};
+
+		/**
+		 * Sets up observer to watch for ANY Showpass iframe anywhere in the document
+		 * Handles both popup widgets and embedded widgets
+		 */
+		const setupShowpassIframeObserver = () => {
+			const documentObserver = new MutationObserver((mutations) => {
+				mutations.forEach((mutation) => {
+					if (mutation.type === "childList") {
+						mutation.addedNodes.forEach((node) => {
+							if (node.nodeType === Node.ELEMENT_NODE) {
+								// Check if the node itself is a Showpass iframe
+								if (
+									node.tagName === "IFRAME" &&
+									node.src &&
+									node.src.includes("showpass.com") &&
+									!node.dataset.decorated
+								) {
+									setTimeout(() => {
+										decorateIframe(node);
+									}, 100);
+								}
+
+								// Look for any Showpass iframes within the added node
+								if (node.querySelectorAll) {
+									const iframes = node.querySelectorAll(
+										'iframe[src*="showpass.com"]'
+									);
+									iframes.forEach((iframe) => {
+										if (
+											iframe.src &&
+											!iframe.dataset.decorated
+										) {
+											setTimeout(() => {
+												decorateIframe(iframe);
+											}, 100);
+										}
+									});
+								}
+							}
+						});
+					}
+
+					// Also watch for src attribute changes on existing iframes
+					if (
+						mutation.type === "attributes" &&
+						mutation.attributeName === "src"
+					) {
+						const target = mutation.target;
+						if (
+							target.tagName === "IFRAME" &&
+							target.src &&
+							target.src.includes("showpass.com") &&
+							!target.dataset.decorated
+						) {
+							setTimeout(() => {
+								decorateIframe(target);
+							}, 100);
+						}
+					}
+				});
 			});
-		});
 
-		mutationObserver.observe(document.documentElement, { attributes: true });
+			documentObserver.observe(document.body, {
+				childList: true,
+				subtree: true,
+				attributes: true,
+				attributeFilter: ["src"],
+			});
 
-		let calendarDIV = document.getElementById("showpass-calendar-widget");
-		if (calendarDIV) {
-			/** Wrap IFrame for embeded calendar */
-			function wrapIFrame(iFrame) {
-				clearInterval(findIFrameInterval);
-				decorateIframe(iFrame);
-			}
-			const findIFrameInterval = setInterval(findIFrame, 100);
-			function findIFrame() {
-				let iFrame = document.getElementsByClassName("showpass-widget-iframe");
-				if (iFrame && iFrame[0] && iFrame[0].src) {
-				wrapIFrame(iFrame[0]);
-			}
-		}
+			return documentObserver;
+		};
+
+		// Initialize the observer automatically
+		setupShowpassIframeObserver();
 	}
-}})(jQuery, window, document);
+})(jQuery, window, document);


### PR DESCRIPTION
Updated iFrame decorator to look for generic showpass iFrames for support for new embeded SDKs

---

In order to test you need to set up a wordpress site locally, and put a GA4 tag on that site, and test to make sure that the query params are appended to the iFrame SRC for all of the widgets